### PR TITLE
Initialize using Stack Consent Manager (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ import {
 } from 'react-native-appodeal';
 
 const adTypes = AppodealAdType.INTERSTITIAL | AppodealAdType.REWARDED_VIDEO | AppodealAdType.BANNER;
+
+// Initialize using Stack Consent Manager. (Requests consent when needed and starts initialisation after)
+Appodeal.synchroniseConsent('Your app key', adTypes)
+
+// OR: Initialize using your own consent implementation
 const consent = true;
 Appodeal.initialize('Your app key', adTypes, consent)
 ```

--- a/RNAppodeal.podspec
+++ b/RNAppodeal.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   s.dependency "Appodeal", "2.6.3"
+  s.dependency "StackConsentManager", "~> 1.0.1"
 end
 
   

--- a/ios/RNAppodeal.m
+++ b/ios/RNAppodeal.m
@@ -17,7 +17,7 @@ STKConsentManagerDisplayDelegate
 @implementation RNAppodeal
 {
     NSString *_appKey;
-    NSInteger *_adType;
+    NSInteger _adType;
 }
 
 @synthesize bridge = _bridge;
@@ -27,6 +27,22 @@ STKConsentManagerDisplayDelegate
 }
 
 RCT_EXPORT_MODULE();
+
+- (void)initialize {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [Appodeal setFramework:APDFrameworkReactNative version:RNAVersion()];
+        
+        [Appodeal setRewardedVideoDelegate:self];
+        [Appodeal setNonSkippableVideoDelegate:self];
+        [Appodeal setBannerDelegate:self];
+        [Appodeal setInterstitialDelegate:self];
+        
+        BOOL consent = STKConsentManager.sharedManager.consentStatus != STKConsentStatusNonPersonalized;
+        [Appodeal initializeWithApiKey:_appKey
+                                 types:AppodealAdTypeFromRNAAdType(_adType)
+                            hasConsent:consent];
+    });
+}
 
 #pragma mark Method export
 
@@ -56,7 +72,7 @@ RCT_EXPORT_METHOD(synchroniseConsent:(NSString *)appKey types:(NSInteger)adType)
         }
         
         if (STKConsentManager.sharedManager.shouldShowConsentDialog != STKConsentBoolTrue) {
-            [strongSelf initialize:_appKey types:_adType];
+            [strongSelf initialize];
             return ;
         }
         
@@ -66,7 +82,7 @@ RCT_EXPORT_METHOD(synchroniseConsent:(NSString *)appKey types:(NSInteger)adType)
             }
             
             if (!STKConsentManager.sharedManager.isConsentDialogReady) {
-                [strongSelf initialize:_appKey types:_adType];
+                [strongSelf initialize];
                 return ;
             }
             UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
@@ -451,11 +467,11 @@ RCT_EXPORT_METHOD(trackInAppPurchase:(double)amount currencyCode:(NSString *)cur
 - (void)consentManagerWillShowDialog:(STKConsentManager *)consentManager {}
 
 - (void)consentManagerDidDismissDialog:(STKConsentManager *)consentManager {
-    [self initialize:_appKey types:_adType];
+    [self initialize];
 }
 
 - (void)consentManager:(STKConsentManager *)consentManager didFailToPresent:(NSError *)error {
-    [self initialize:_appKey types:_adType];
+    [self initialize];
 }
 
 #pragma mark - Noop

--- a/ios/RNAppodeal.m
+++ b/ios/RNAppodeal.m
@@ -92,6 +92,7 @@ RCT_EXPORT_METHOD(synchroniseConsent:(NSString *)appKey types:(NSInteger)adType)
         }];
     });
 }
+
 RCT_EXPORT_METHOD(show:(int)showType placement:(NSString *)placement result:(RCTResponseSenderBlock)callback) {
     dispatch_async(dispatch_get_main_queue(), ^{
         BOOL result = [Appodeal showAd:AppodealShowStyleFromRNAAdType(showType)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "tsc": "tsc --project .",
-    "lint": "tslint --project ."
+    "lint": "tslint --project .",
+    "prepare": "npm run tsc"
   },
   "author": "Appodeal <https://appodeal.com>",
   "license": "MIT",

--- a/src/RNAppodeal.ts
+++ b/src/RNAppodeal.ts
@@ -42,6 +42,10 @@ export default {
     adTypes: AdTypeType,
     consent: boolean
   ) => RNAppodeal.initialize(appKey, adTypes, consent),
+  synchroniseConsent: (
+    appKey: String,
+    adTypes: AdTypeType
+  ) => RNAppodeal.synchroniseConsent(appKey, adTypes),
   show: (
     adTypes: AdTypeType,
     placement: string,


### PR DESCRIPTION
This allows React Native users to get consent using the Stack Consent Manager (on iOS).
I aligned the code with the example on: https://github.com/appodeal/appodeal-ios-demo/blob/master/AppodealObjectiveCDemo/AppodealObjectiveCDemo/ASAppDelegate.m