### PR TITLE
The dist folder doesn't exist in node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "tsc": "tsc --project .",
-    "lint": "tslint --project ."
+    "lint": "tslint --project .",
+    "prepublish": "npm run tsc"
   },
   "author": "Appodeal <https://appodeal.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "tsc": "tsc --project .",
     "lint": "tslint --project .",
-    "prepublish": "npm run tsc"
+    "prepare": "npm run tsc"
   },
   "author": "Appodeal <https://appodeal.com>",
   "license": "MIT",


### PR DESCRIPTION
Currently the latest update can't be used because the dist folder doesn't exist after installing the package.