### PR TITLE
[README] increase Appodeal version for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add dependencies into `build.gradle` (module: app)
 ``` groovy
 dependencies {
     ...
-    implementation 'com.appodeal.ads:sdk:2.6.3.+'
+    implementation 'com.appodeal.ads:sdk:2.7.3.+'
     ...
 }
 ```


### PR DESCRIPTION
Hi! The version for Android is not up-to-date in the integration guide. It should be `2.7.3.+` instead of `2.6.3.+`. A few days I got my app suspended due to having old version of Appodeal which contains Vungle SDK which version was not compliant with Google Play Privacy. I had my other two apps suspended because of the same reason in summer. Anyways, if there will be people like me who copy from github and forget checking the actual version on the site (which was my mistake), let the version be up-to-date :)