### PR TITLE
Fix: resolve #148 and improve compatibility with legacy architecture

### DIFF
--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealBannerView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealBannerView.kt
@@ -12,6 +12,7 @@ import com.appodeal.ads.Appodeal
 import com.appodeal.ads.BannerView
 import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandler
 import com.appodeal.rnappodeal.constants.BannerEvents
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.UIManagerHelper
@@ -118,7 +119,12 @@ class RCTAppodealBannerView(context: Context) : ReactViewGroup(context), RNAppod
     ) {
         val dispatcher: EventDispatcher? =
             UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewId)
-        dispatcher?.dispatchEvent(OnViewEvent(surfaceId, viewId, eventName, params))
+        
+        val safeParams: WritableMap? = params?.let { original ->
+            Arguments.createMap().apply { merge(original) }
+        }
+        
+        dispatcher?.dispatchEvent(OnViewEvent(surfaceId, viewId, eventName, safeParams))
     }
 
     private class OnViewEvent(

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealMrecView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealMrecView.kt
@@ -12,6 +12,7 @@ import com.appodeal.ads.Appodeal
 import com.appodeal.ads.MrecView
 import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandler
 import com.appodeal.rnappodeal.constants.MrecEvents
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.UIManagerHelper
@@ -109,7 +110,12 @@ class RCTAppodealMrecView(context: Context) : ReactViewGroup(context), RNAppodea
     ) {
         val dispatcher: EventDispatcher? =
             UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewId)
-        dispatcher?.dispatchEvent(OnViewEvent(surfaceId, viewId, eventName, params))
+        
+        val safeParams: WritableMap? = params?.let { original ->
+            Arguments.createMap().apply { merge(original) }
+        }
+        
+        dispatcher?.dispatchEvent(OnViewEvent(surfaceId, viewId, eventName, safeParams))
     }
 
     private class OnViewEvent(

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAEventDispatcher.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAEventDispatcher.kt
@@ -3,6 +3,7 @@ package com.appodeal.rnappodeal
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
@@ -264,8 +265,13 @@ internal class RNAEventDispatcher(
 
         try {
             val prefixedEventName = EVENT_PREFIX + eventName
+            
+            val safePayload: WritableMap? = payload?.let { original ->
+                Arguments.createMap().apply { merge(original) }
+            }
+            
             reactContext.getJSModule(RCTDeviceEventEmitter::class.java)
-                .emit(prefixedEventName, payload)
+                .emit(prefixedEventName, safePayload)
         } catch (e: Exception) {
             Log.e(TAG, "Error sending event: $eventName", e)
         }

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealBannerViewManagerImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealBannerViewManagerImpl.kt
@@ -69,6 +69,15 @@ internal class RNAppodealBannerViewManagerImpl(
         )
     }
 
+    fun getExportedCustomDirectEventTypeConstants(): Map<String?, Any?>? {
+        return mapOf(
+            BannerEvents.ON_AD_LOADED to mapOf("registrationName" to BannerEvents.ON_AD_LOADED),
+            BannerEvents.ON_AD_FAILED_TO_LOAD to mapOf("registrationName" to BannerEvents.ON_AD_FAILED_TO_LOAD),
+            BannerEvents.ON_AD_CLICKED to mapOf("registrationName" to BannerEvents.ON_AD_CLICKED),
+            BannerEvents.ON_AD_EXPIRED to mapOf("registrationName" to BannerEvents.ON_AD_EXPIRED)
+        )
+    }
+
     private fun getAppodealBannerView(context: Context): BannerView {
         return appodealBannerViewRef.get() ?: run {
             val newBannerView = Appodeal.getBannerView(context.applicationContext)

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealMrecViewManagerImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealMrecViewManagerImpl.kt
@@ -66,6 +66,15 @@ internal class RNAppodealMrecViewManagerImpl(
         )
     }
 
+    fun getExportedCustomDirectEventTypeConstants(): Map<String?, Any?>? {
+        return mapOf(
+            MrecEvents.ON_AD_LOADED to mapOf("registrationName" to MrecEvents.ON_AD_LOADED),
+            MrecEvents.ON_AD_FAILED_TO_LOAD to mapOf("registrationName" to MrecEvents.ON_AD_FAILED_TO_LOAD),
+            MrecEvents.ON_AD_CLICKED to mapOf("registrationName" to MrecEvents.ON_AD_CLICKED),
+            MrecEvents.ON_AD_EXPIRED to mapOf("registrationName" to MrecEvents.ON_AD_EXPIRED)
+        )
+    }
+
     private fun getAppodealMrecView(context: Context): MrecView {
         return appodealMrecViewRef.get() ?: run {
             val newMrecView = Appodeal.getMrecView(context.applicationContext)

--- a/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealBannerViewManager.java
+++ b/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealBannerViewManager.java
@@ -6,8 +6,10 @@ import androidx.annotation.Nullable;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.appodeal.rnappodeal.constants.BannerEvents;
 
 import java.util.Map;
+import java.util.HashMap;
 
 public class RNAppodealBannerViewManager extends SimpleViewManager<RCTAppodealBannerView> {
 
@@ -39,6 +41,12 @@ public class RNAppodealBannerViewManager extends SimpleViewManager<RCTAppodealBa
     @Override
     public Map<String, Object> getExportedViewConstants() {
         return bannerViewManagerImpl.getExportedViewConstants();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return bannerViewManagerImpl.getExportedCustomDirectEventTypeConstants();
     }
 
     @ReactProp(name = "adSize")

--- a/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealMrecViewManager.java
+++ b/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealMrecViewManager.java
@@ -6,8 +6,10 @@ import androidx.annotation.Nullable;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.appodeal.rnappodeal.constants.MrecEvents;
 
 import java.util.Map;
+import java.util.HashMap;
 
 public class RNAppodealMrecViewManager extends SimpleViewManager<RCTAppodealMrecView> {
 
@@ -39,6 +41,12 @@ public class RNAppodealMrecViewManager extends SimpleViewManager<RCTAppodealMrec
     @Override
     public Map<String, Object> getExportedViewConstants() {
         return mrecViewManagerImpl.getExportedViewConstants();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return mrecViewManagerImpl.getExportedCustomDirectEventTypeConstants();
     }
 
     @ReactProp(name = "placement")

--- a/ios/RNAppodeal.mm
+++ b/ios/RNAppodeal.mm
@@ -80,20 +80,9 @@ RCT_EXPORT_METHOD(show:(double)showType
   rootViewController:RCTPresentedViewController()];
 }
 
-RCT_EXPORT_METHOD(isLoaded:(double)showType
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isLoaded:(double)showType) {
     BOOL isLoaded = [Appodeal isReadyForShowWithStyle:AppodealShowStyleFromRNAAdType(showType)];
-    resolve(@(isLoaded));
-}
-
-RCT_EXPORT_METHOD(canShow:(double)showType
-                  placement:(NSString *)placement
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject) {
-    BOOL canShow = [Appodeal canShow:AppodealAdTypeFromRNAAdType(showType)
-                        forPlacement:placement];
-    resolve(@(canShow));
+    return @(isLoaded);
 }
 
 RCT_EXPORT_METHOD(cache:(double)adType) {

--- a/ios/RNAppodealBannerViewComponentView.h
+++ b/ios/RNAppodealBannerViewComponentView.h
@@ -1,3 +1,4 @@
+#ifdef RCT_NEW_ARCH_ENABLED
 #import <Foundation/Foundation.h>
 #import <React/RCTViewComponentView.h>
 
@@ -8,3 +9,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/RNAppodealBannerViewComponentView.mm
+++ b/ios/RNAppodealBannerViewComponentView.mm
@@ -1,3 +1,4 @@
+#ifdef RCT_NEW_ARCH_ENABLED
 #import "RNAppodealBannerViewComponentView.h"
 #import "RNAppodealBannerView.h"
 
@@ -97,3 +98,4 @@ using namespace facebook::react;
 Class<RCTComponentViewProtocol> RNAppodealBannerViewCls(void) {
     return RNAppodealBannerViewComponentView.class;
 }
+#endif

--- a/ios/RNAppodealMrecViewComponentView.h
+++ b/ios/RNAppodealMrecViewComponentView.h
@@ -1,3 +1,4 @@
+#ifdef RCT_NEW_ARCH_ENABLED
 #import <Foundation/Foundation.h>
 #import <React/RCTViewComponentView.h>
 
@@ -8,3 +9,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/RNAppodealMrecViewComponentView.mm
+++ b/ios/RNAppodealMrecViewComponentView.mm
@@ -1,3 +1,4 @@
+#ifdef RCT_NEW_ARCH_ENABLED
 #import "RNAppodealMrecViewComponentView.h"
 #import "RNAppodealBannerView.h"
 
@@ -89,3 +90,4 @@ using namespace facebook::react;
 Class<RCTComponentViewProtocol> RNAppodealMrecViewCls(void) {
     return RNAppodealMrecViewComponentView.class;
 }
+#endif

--- a/src/RNAppodealEvents.ts
+++ b/src/RNAppodealEvents.ts
@@ -72,3 +72,19 @@ export namespace AppodealRewardedEvents {
   /** Fired when rewarded video ad is clicked */
   export const CLICKED = 'onRewardedVideoClicked';
 }
+
+/**
+ * Mrec ad events
+ */
+export namespace AppodealMrecEvents {
+  /** Fired when MREC ad is loaded successfully */
+  export const LOADED = 'onMrecLoaded';
+  /** Fired when MREC ad fails to load */
+  export const FAILED_TO_LOAD = 'onMrecFailedToLoad';
+  /** Fired when MREC ad is shown */
+  export const SHOWN = 'onMrecShown';
+  /** Fired when MREC ad is clicked */
+  export const CLICKED = 'onMrecClicked';
+  /** Fired when MREC ad expires */
+  export const EXPIRED = 'onMrecExpired';
+}


### PR DESCRIPTION
This PR includes three commits that resolve the issue reported at https://github.com/appodeal/react-native-appodeal/issues/148 and add improvements for compatibility with React Native's old architecture. The main goal is to prevent initialization crashes and provide robust fallbacks for bridge/view manager usage on legacy setups.