### PR TITLE
fix: auto-merge README-sync PR via GitHub App (master is protected)

### DIFF
--- a/.github/workflows/update-readme-deps.yml
+++ b/.github/workflows/update-readme-deps.yml
@@ -54,7 +54,7 @@ jobs:
             echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          BRANCH="chore/update-readme-deps-${{ github.run_id }}"
+          BRANCH="chore/update-readme-deps-${{ github.run_id }}-${{ github.run_attempt }}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH"

--- a/.github/workflows/update-readme-deps.yml
+++ b/.github/workflows/update-readme-deps.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: update-readme-deps
@@ -41,14 +42,24 @@ jobs:
           APPODEAL_API_URL: ${{ vars.APPODEAL_API_URL }}
         run: node scripts/update-readme-deps.mjs
 
-      - name: Commit changes if any
+      - name: Open and merge PR if README changed
+        # master is protected (changes must go through a PR), so the bot cannot push
+        # directly. It pushes a branch, opens a PR, and merges it — no manual step.
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet -- README.md; then
             echo "README dependencies already up to date."
             exit 0
           fi
+          BRANCH="chore/update-readme-deps-${{ github.run_id }}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
           git add README.md
           git commit -m "chore: sync README dependency lists from Wizard API"
-          git push
+          git push origin "$BRANCH"
+          gh pr create --base master --head "$BRANCH" \
+            --title "chore: sync README dependency lists from Wizard API" \
+            --body "Automated update from the Appodeal Dependencies Wizard API."
+          gh pr merge "$BRANCH" --squash --delete-branch

--- a/.github/workflows/update-readme-deps.yml
+++ b/.github/workflows/update-readme-deps.yml
@@ -42,14 +42,16 @@ jobs:
           APPODEAL_API_URL: ${{ vars.APPODEAL_API_URL }}
         run: node scripts/update-readme-deps.mjs
 
-      - name: Open and merge PR if README changed
-        # master is protected (changes must go through a PR), so the bot cannot push
-        # directly. It pushes a branch, opens a PR, and merges it — no manual step.
+      - name: Create PR if README changed
+        # master is protected (changes must go through a PR), so the bot opens a PR as
+        # github-actions[bot]. A different identity (the App below) approves and merges it.
+        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet -- README.md; then
             echo "README dependencies already up to date."
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           BRANCH="chore/update-readme-deps-${{ github.run_id }}"
@@ -62,4 +64,23 @@ jobs:
           gh pr create --base master --head "$BRANCH" \
             --title "chore: sync README dependency lists from Wizard API" \
             --body "Automated update from the Appodeal Dependencies Wizard API."
-          gh pr merge "$BRANCH" --squash --delete-branch
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Generate App token for approval
+        # A second identity is required: github-actions[bot] (the PR author) cannot approve
+        # its own PR. The GitHub App acts as the reviewer whose approval branch protection counts.
+        if: steps.pr.outputs.created == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Approve and merge PR
+        if: steps.pr.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr review "${{ steps.pr.outputs.branch }}" --approve
+          gh pr merge "${{ steps.pr.outputs.branch }}" --squash --delete-branch


### PR DESCRIPTION
## Problem

The merged `update-readme-deps` workflow pushes the regenerated README directly to `master`, which branch protection rejects:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
```

`master` also requires an approving review, and `GITHUB_TOKEN` cannot satisfy that (a bot cannot approve its own PR, and token-based approvals don't count).

## Fix

The workflow now uses two identities:

1. **`github-actions[bot]`** (default `GITHUB_TOKEN`) — regenerates the README, pushes a branch, and opens the PR.
2. **GitHub App** (`appodeal-dependabot`, via `APP_ID` / `APP_PRIVATE_KEY` secrets) — approves and squash-merges the PR.

A second identity is mandatory: the PR author can't approve its own PR. The source branch is deleted on merge.

```
cron / push / manual
  → regenerate README → no diff? stop
  → github-actions[bot] opens PR
  → App token minted → App approves + squash-merges + deletes branch
master updated, zero-touch
```

## Required setup (before this works)

- Repo secrets: `APP_ID`, `APP_PRIVATE_KEY`
- `appodeal-dependabot` installed on the repo with **Pull requests: write** + **Contents: write**
- If the master ruleset requires CODEOWNERS approval specifically, add the App to `CODEOWNERS`

## Note

This PR itself needs a one-time human approval to merge (chicken-and-egg). Once merged, subsequent README-sync PRs are approved and merged automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)