### PR TITLE
fix: drop duplicated repositories block from generated Android deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,6 @@ Add dependencies into `android/app/build.gradle`
 
 <!-- appodeal-deps:android:start -->
 ``` kotlin
-repositories {
-    maven { url = uri("https://artifactory.appodeal.com/appodeal") }
-}
-/* build.gradle.kts */
 dependencies {
     implementation("com.appodeal.ads.sdk:core:4.1.0")
     // Bidon

--- a/scripts/update-readme-deps.mjs
+++ b/scripts/update-readme-deps.mjs
@@ -83,8 +83,8 @@ function fenced(lang, body) {
 /**
  * Keep only the `dependencies { ... }` block from the Android response. The Wizard
  * prepends a `repositories { ... }` block (already documented separately in the README's
- * "Add repository into android/build.gradle" section) and a `/* build.gradle.kts *​/`
- * label, which would otherwise duplicate the repository setup and mislead readers.
+ * "Add repository into android/build.gradle" section) and a build.gradle.kts label
+ * comment, which would otherwise duplicate the repository setup and mislead readers.
  */
 function androidDependenciesOnly(text) {
   const idx = text.search(/^dependencies\s*\{/m);

--- a/scripts/update-readme-deps.mjs
+++ b/scripts/update-readme-deps.mjs
@@ -81,6 +81,20 @@ function fenced(lang, body) {
 }
 
 /**
+ * Keep only the `dependencies { ... }` block from the Android response. The Wizard
+ * prepends a `repositories { ... }` block (already documented separately in the README's
+ * "Add repository into android/build.gradle" section) and a `/* build.gradle.kts *​/`
+ * label, which would otherwise duplicate the repository setup and mislead readers.
+ */
+function androidDependenciesOnly(text) {
+  const idx = text.search(/^dependencies\s*\{/m);
+  if (idx === -1) {
+    throw new Error('Could not find `dependencies {` in the Android API response');
+  }
+  return text.slice(idx);
+}
+
+/**
  * Inject the React Native linking lines into the iOS Podfile target. The Wizard renders
  * a plain native target (`target 'Sample' do ... end`); RN apps additionally need the
  * autolinking calls, otherwise the copied Podfile won't build. Everything else from the
@@ -128,7 +142,7 @@ async function main() {
 
   // android uses kts (`kt`) verbatim; ios ignores the language, returns Ruby, and gets
   // the React Native linking injected into its target.
-  const android = await fetchDependencyBlock('android', version, 'kt');
+  const android = androidDependenciesOnly(await fetchDependencyBlock('android', version, 'kt'));
   const ios = addReactNativeLinking(await fetchDependencyBlock('ios', version));
 
   let readme = await readFile(README, 'utf8');


### PR DESCRIPTION
## Problem

The auto-generated Android block (`android/app/build.gradle`) includes the Wizard's `repositories { maven { ... } }` block plus a `/* build.gradle.kts */` label:

```kotlin
repositories {
    maven { url = uri("https://artifactory.appodeal.com/appodeal") }
}
/* build.gradle.kts */
dependencies {
    ...
}
```

This duplicates the dedicated **"Add repository into `android/build.gradle`"** section right below, and the repository conventionally belongs at project level, not in the app module — so the snippet is both redundant and misleading.

## Fix

`androidDependenciesOnly()` keeps only the `dependencies { ... }` block from the API response. The repository setup stays documented in its own section (unchanged). iOS is untouched (its `source` lines are part of the Podfile, not duplicated).

README regenerated in this PR to reflect the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)