### PR TITLE
feat: Native ads support for React Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 4.3.1
+
+### Features
+
+- **Composable native ads**: AdMob-style JSX layout via
+  `AppodealNativeAdView` + asset views (`media` / `icon` / `title` /
+  `description` / `callToAction` / `attribution`) on Android and iOS.
+  Matches Appodeal Android custom `NativeAdView` and iOS `APDNativeAdView`
+  asset binding — app owns styling in React Native.
+
+### Changes
+
+- Stock `<AppodealNative adTemplate="..." />` remains for
+  `newsFeed` / `appWall` / `contentStream` only (no app-specific templates).
+
 ## 4.3.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 4.3.0
+
+### Features
+
+- **Native ads**: full React Native bridge for Appodeal Native (the previously
+  missing format). Adds `AppodealAdType.NATIVE`, module APIs
+  (`getNativeAds`, `getAvailableNativeAdsCount`, `destroyNativeAd`,
+  `cacheNativeAds`, `setPreferredNativeContentType`),
+  `AppodealNativeEvents`, and the `<AppodealNative />` view component
+  (templates: `newsFeed` / `appWall` / `contentStream`).
+- Android: `Appodeal.NATIVE` type mapping, `NativeCallbacks`, ad store,
+  template `NativeAdView` registration.
+- iOS: `APDNativeAdQueue` store, `getViewForPlacement` view binding,
+  native event constants.
+
 ## 4.2.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -546,7 +546,8 @@ Appodeal.initialize('YOUR_APPODEAL_APP_KEY',
   AppodealAdType.INTERSTITIAL | 
   AppodealAdType.REWARDED_VIDEO | 
   AppodealAdType.BANNER | 
-  AppodealAdType.MREC
+  AppodealAdType.MREC |
+  AppodealAdType.NATIVE
 );
 ```
 
@@ -558,6 +559,7 @@ Use the type codes below to set the preferred ad format:
 - `AppodealAdType.REWARDED_VIDEO` for rewarded videos.
 - `AppodealAdType.BANNER` for banners.
 - `AppodealAdType.MREC` for 300*250 banners.
+- `AppodealAdType.NATIVE` for native ads.
 
 2. Configure SDK
 
@@ -816,6 +818,45 @@ import { AppodealMrec } from 'react-native-appodeal';
   onAdExpired={() => console.log('MREC expired')}
   style={{ width: 300, height: 250 }}
 />
+```
+
+### Native ads
+
+Pull native ads from the SDK cache, then bind each ad id to `<AppodealNative />`:
+
+```javascript
+import Appodeal, {
+  AppodealAdType,
+  AppodealNative,
+  AppodealNativeEvents,
+} from 'react-native-appodeal';
+
+// Include NATIVE in initialize(), then:
+Appodeal.cacheNativeAds(3);
+
+Appodeal.addEventListener(AppodealNativeEvents.LOADED, () => {
+  const ads = Appodeal.getNativeAds(1);
+  // ads[0] => { id, title, description, callToAction, rating, containsVideo, predictedEcpm }
+});
+
+// Render a platform template for a pulled ad:
+<AppodealNative
+  adId={ads[0].id}
+  placement="default"
+  template="contentStream" // "newsFeed" | "appWall" | "contentStream"
+  onAdLoaded={() => console.log('Native shown')}
+  onAdFailedToLoad={() => console.log('Native failed')}
+  onAdClicked={() => console.log('Native clicked')}
+  style={{ width: '100%', height: 300 }}
+/>
+```
+
+Optional:
+
+```javascript
+Appodeal.setPreferredNativeContentType('auto'); // 'auto' | 'noVideo' | 'video'
+Appodeal.getAvailableNativeAdsCount();
+Appodeal.destroyNativeAd(adId);
 ```
 
 ## Privacy Policy and Consent

--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ Appodeal.addEventListener(AppodealNativeEvents.LOADED, () => {
 <AppodealNative
   adId={ads[0].id}
   placement="default"
-  template="contentStream" // "newsFeed" | "appWall" | "contentStream"
+  adTemplate="contentStream" // "newsFeed" | "appWall" | "contentStream"
   onAdLoaded={() => console.log('Native shown')}
   onAdFailedToLoad={() => console.log('Native failed')}
   onAdClicked={() => console.log('Native clicked')}

--- a/android/src/main/java/com/appodeal/rnappodeal/NativeAdViewAssetBinder.java
+++ b/android/src/main/java/com/appodeal/rnappodeal/NativeAdViewAssetBinder.java
@@ -1,0 +1,47 @@
+package com.appodeal.rnappodeal;
+
+import android.view.View;
+import android.widget.TextView;
+
+import com.appodeal.ads.nativead.NativeAdView;
+import com.appodeal.ads.nativead.NativeIconView;
+import com.appodeal.ads.nativead.NativeMediaView;
+
+/**
+ * Binds custom native-ad assets onto {@link NativeAdView}.
+ *
+ * <p>Appodeal's {@code NativeAdView} keeps JavaBean setters for Java callers, but the Kotlin
+ * metadata is obfuscated — so a Kotlin subclass cannot resolve {@code setMediaView} /
+ * {@code mediaView = ...}. Call the setters from Java instead.
+ */
+public final class NativeAdViewAssetBinder {
+  private NativeAdViewAssetBinder() {}
+
+  public static void bind(
+      NativeAdView view,
+      NativeMediaView media,
+      NativeIconView icon,
+      View title,
+      View description,
+      View callToAction,
+      TextView attribution) {
+    if (media != null) {
+      view.setMediaView(media);
+    }
+    if (icon != null) {
+      view.setIconView(icon);
+    }
+    if (title != null) {
+      view.setTitleView(title);
+    }
+    if (description != null) {
+      view.setDescriptionView(description);
+    }
+    if (callToAction != null) {
+      view.setCallToActionView(callToAction);
+    }
+    if (attribution != null) {
+      view.setAdAttributionView(attribution);
+    }
+  }
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeAdView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeAdView.kt
@@ -1,17 +1,16 @@
 package com.appodeal.rnappodeal
 
 import android.content.Context
-import android.graphics.Color
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
+import android.widget.TextView
 import com.appodeal.ads.NativeAd
 import com.appodeal.ads.nativead.NativeAdView
-import com.appodeal.ads.nativead.NativeAdViewAppWall
-import com.appodeal.ads.nativead.NativeAdViewContentStream
-import com.appodeal.ads.nativead.NativeAdViewNewsFeed
+import com.appodeal.ads.nativead.NativeIconView
+import com.appodeal.ads.nativead.NativeMediaView
 import com.appodeal.ads.nativead.Position
 import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandler
 import com.appodeal.rnappodeal.constants.NativeEvents
@@ -20,17 +19,16 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.views.view.ReactViewGroup
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
- * RN host for Appodeal **stock** native templates
- * (`newsFeed` / `appWall` / `contentStream`).
- *
- * Custom layouts use [RCTAppodealNativeAdView] + asset children instead.
+ * Composable native ad root — matches Appodeal Android demo custom [NativeAdView]
+ * (`native_ad_view_custom.xml`): asset children + [registerView].
  */
-class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppodealEventHandler {
+class RCTAppodealNativeAdView(context: Context) :
+    NativeAdView(context),
+    RNAppodealEventHandler {
 
     private val reactContext: ReactContext = context as ReactContext
     private val surfaceId: Int by lazy { UIManagerHelper.getSurfaceId(reactContext) }
@@ -56,57 +54,34 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             }
         }
 
-    var adTemplate: String = "contentStream"
-        set(value) {
-            val normalized = value.ifBlank { "contentStream" }
-            if (field == normalized) return
-            field = normalized
-            tearDownAdView()
-            boundAdId = null
-            bindGeneration++
-            scheduleBind(BIND_DELAY_MS)
-        }
-
-    private var adView: NativeAdView? = null
     private var boundAdId: String? = null
     private var bindRunnable: Runnable? = null
     private var bindGeneration: Int = 0
     private var bindAttempts: Int = 0
 
-    private val measureAndLayout = Runnable {
-        val w = measuredWidth
-        val h = measuredHeight
-        if (w <= 0 || h <= 0) return@Runnable
-        for (i in 0 until childCount) {
-            val child = getChildAt(i)
-            child.visibility = VISIBLE
-            child.measure(
-                MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
-            )
-            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
-        }
-    }
-
     init {
         liveViews.add(WeakReference(this))
         visibility = VISIBLE
-        setBackgroundColor(Color.TRANSPARENT)
-        contentDescription = "appodeal-native-host"
+        setAdChoicesPosition(Position.END_TOP)
         clipChildren = false
         clipToPadding = false
+        contentDescription = "appodeal-native-ad-view"
     }
 
-    override fun requestLayout() {
-        super.requestLayout()
-        post(measureAndLayout)
+    fun onAssetChanged() {
+        if (boundAdId != null) {
+            boundAdId = null
+            bindGeneration++
+        }
+        if (!adId.isNullOrEmpty()) {
+            scheduleBind(BIND_DELAY_MS)
+        }
     }
 
-    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-        super.onLayout(changed, left, top, right, bottom)
-        post(measureAndLayout)
-        if (right - left > 0 && bottom - top > 0 && boundAdId == null && !adId.isNullOrEmpty()) {
-            scheduleBind(0)
+    override fun onViewAdded(child: View?) {
+        super.onViewAdded(child)
+        if (!adId.isNullOrEmpty() && boundAdId == null) {
+            scheduleBind(BIND_DELAY_MS)
         }
     }
 
@@ -117,11 +92,21 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         }
     }
 
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        if (right - left > 0 && bottom - top > 0 && boundAdId == null && !adId.isNullOrEmpty()) {
+            scheduleBind(0)
+        }
+    }
+
     fun cleanup() {
         bindRunnable?.let { uiHandler.removeCallbacks(it) }
         bindRunnable = null
         bindGeneration++
-        tearDownAdView()
+        try {
+            unregisterView()
+        } catch (_: Exception) {
+        }
         boundAdId = null
         bindAttempts = 0
         val self = this
@@ -131,63 +116,6 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     fun onActivityReady() {
         if (boundAdId == null && !adId.isNullOrEmpty()) {
             scheduleBind(0)
-        }
-    }
-
-    private fun tearDownAdView() {
-        val view = adView
-        adView = null
-        if (view != null) {
-            try {
-                view.unregisterView()
-            } catch (_: Exception) {
-            }
-            try {
-                view.destroy()
-            } catch (_: Exception) {
-            }
-            (view.parent as? ViewGroup)?.removeView(view)
-        }
-        removeAllViews()
-    }
-
-    private fun ensureAdView(): NativeAdView {
-        adView?.let { existing ->
-            existing.visibility = VISIBLE
-            post(measureAndLayout)
-            return existing
-        }
-
-        val view = createTemplate(adTemplate).apply {
-            visibility = VISIBLE
-            descendantFocusability = FOCUS_BLOCK_DESCENDANTS
-            setAdChoicesPosition(Position.END_TOP)
-            contentDescription = "appodeal-native-ad"
-            layoutParams = FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-        }
-
-        removeAllViews()
-        this.visibility = VISIBLE
-        addView(view)
-        view.bringToFront()
-        try {
-            (parent as? ViewGroup)?.bringChildToFront(this)
-        } catch (_: Exception) {
-        }
-        post(measureAndLayout)
-
-        adView = view
-        return view
-    }
-
-    private fun createTemplate(template: String): NativeAdView {
-        return when (template) {
-            "newsFeed" -> NativeAdViewNewsFeed(context)
-            "appWall" -> NativeAdViewAppWall(context)
-            else -> NativeAdViewContentStream(context)
         }
     }
 
@@ -249,37 +177,40 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             return
         }
 
-        val view = ensureAdView()
-        view.visibility = VISIBLE
-        runMeasureAndLayoutNow()
-
-        if (view.width <= 0 || view.height <= 0) {
-            if (!retry(gen, id, "child still 0x0 after layout")) {
-                dispatchFailed(id, "child still 0x0 after layout")
+        val assets = collectAssets(this)
+        if (assets.media == null && assets.icon == null) {
+            if (!retry(gen, id, "missing media/icon asset")) {
+                dispatchFailed(id, "composable native ad requires media or icon asset")
             }
             return
         }
 
         try {
-            view.unregisterView()
+            unregisterView()
         } catch (_: Exception) {
         }
 
+        // Same wiring as native_ad_view_custom.xml attrs → registerView.
+        assets.media?.let { setMediaView(it) }
+        assets.icon?.let { setIconView(it) }
+        assets.title?.let { setTitleView(it) }
+        assets.description?.let { setDescriptionView(it) }
+        assets.callToAction?.let { setCallToActionView(it) }
+        assets.attribution?.let { setAdAttributionView(it) }
+
         val registered = try {
-            view.registerView(ad, placement)
+            registerView(ad, placement)
         } catch (e: Exception) {
             Log.e(TAG, "registerView threw", e)
             false
         }
 
-        view.visibility = VISIBLE
-        this.visibility = VISIBLE
-        runMeasureAndLayoutNow()
-
         Log.d(
             TAG,
-            "registerView id=$id result=$registered host=${measuredWidth}x${measuredHeight} " +
-                "childSize=${view.width}x${view.height} template=$adTemplate"
+            "composable registerView id=$id result=$registered " +
+                "size=${measuredWidth}x${measuredHeight} " +
+                "media=${assets.media != null} icon=${assets.icon != null} " +
+                "title=${assets.title != null} cta=${assets.callToAction != null}"
         )
 
         if (gen != bindGeneration) return
@@ -287,29 +218,9 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         if (registered) {
             boundAdId = id
             bindAttempts = 0
-            uiHandler.postDelayed({
-                if (gen != bindGeneration) return@postDelayed
-                view.visibility = VISIBLE
-                runMeasureAndLayoutNow()
-            }, 100L)
             dispatchLoaded(id)
         } else if (!retry(gen, id, "registerView returned false")) {
             dispatchFailed(id, "registerView returned false")
-        }
-    }
-
-    private fun runMeasureAndLayoutNow() {
-        val w = measuredWidth
-        val h = measuredHeight
-        if (w <= 0 || h <= 0) return
-        for (i in 0 until childCount) {
-            val child = getChildAt(i)
-            child.visibility = VISIBLE
-            child.measure(
-                MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
-            )
-            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
         }
     }
 
@@ -349,7 +260,7 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             NativeEvents.ON_NATIVE_EXPIRED -> {
                 if (boundAdId == null) return
                 try {
-                    adView?.unregisterView()
+                    unregisterView()
                 } catch (_: Exception) {
                 }
                 boundAdId = null
@@ -387,12 +298,21 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         }
     }
 
+    private data class Assets(
+        val media: NativeMediaView?,
+        val icon: NativeIconView?,
+        val title: TextView?,
+        val description: TextView?,
+        val callToAction: View?,
+        val attribution: View?
+    )
+
     companion object {
-        private const val TAG = "RNAppodealNative"
+        private const val TAG = "RNAppodealNativeAd"
         private const val MAX_BIND_ATTEMPTS = 6
         private const val BIND_DELAY_MS = 200L
 
-        private val liveViews = CopyOnWriteArrayList<WeakReference<RCTAppodealNativeView>>()
+        private val liveViews = CopyOnWriteArrayList<WeakReference<RCTAppodealNativeAdView>>()
 
         fun notifyActivityReady() {
             prune()
@@ -406,7 +326,7 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
                 if (view.adId == adId || view.boundAdId == adId) {
                     view.bindGeneration++
                     try {
-                        view.adView?.unregisterView()
+                        view.unregisterView()
                     } catch (_: Exception) {
                     }
                     view.boundAdId = null
@@ -416,6 +336,36 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
         private fun prune() {
             liveViews.removeAll { it.get() == null }
+        }
+
+        private fun collectAssets(root: ViewGroup): Assets {
+            var media: NativeMediaView? = null
+            var icon: NativeIconView? = null
+            var title: TextView? = null
+            var description: TextView? = null
+            var callToAction: View? = null
+            var attribution: View? = null
+
+            fun walk(view: View) {
+                if (view is RCTAppodealNativeAssetView) {
+                    when (view.assetType) {
+                        "media" -> media = view.mediaView() ?: media
+                        "icon" -> icon = view.iconView() ?: icon
+                        "title" -> title = view.textView() ?: title
+                        "description" -> description = view.textView() ?: description
+                        "callToAction" -> callToAction = view.textView() ?: callToAction
+                        "attribution" -> attribution = view.textView() ?: attribution
+                    }
+                }
+                if (view is ViewGroup) {
+                    for (i in 0 until view.childCount) {
+                        walk(view.getChildAt(i))
+                    }
+                }
+            }
+
+            walk(root)
+            return Assets(media, icon, title, description, callToAction, attribution)
         }
     }
 }

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeAdView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeAdView.kt
@@ -191,12 +191,14 @@ class RCTAppodealNativeAdView(context: Context) :
         }
 
         // Same wiring as native_ad_view_custom.xml attrs → registerView.
-        assets.media?.let { setMediaView(it) }
-        assets.icon?.let { setIconView(it) }
-        assets.title?.let { setTitleView(it) }
-        assets.description?.let { setDescriptionView(it) }
-        assets.callToAction?.let { setCallToActionView(it) }
-        assets.attribution?.let { setAdAttributionView(it) }
+        // NativeAdView exposes JavaBean setters; from a Kotlin subclass those
+        // must be assigned as properties (setMediaView(...) does not resolve).
+        assets.media?.let { mediaView = it }
+        assets.icon?.let { iconView = it }
+        assets.title?.let { titleView = it }
+        assets.description?.let { descriptionView = it }
+        assets.callToAction?.let { callToActionView = it }
+        assets.attribution?.let { adAttributionView = it }
 
         val registered = try {
             registerView(ad, placement)
@@ -304,7 +306,7 @@ class RCTAppodealNativeAdView(context: Context) :
         val title: TextView?,
         val description: TextView?,
         val callToAction: View?,
-        val attribution: View?
+        val attribution: TextView?
     )
 
     companion object {
@@ -344,7 +346,7 @@ class RCTAppodealNativeAdView(context: Context) :
             var title: TextView? = null
             var description: TextView? = null
             var callToAction: View? = null
-            var attribution: View? = null
+            var attribution: TextView? = null
 
             fun walk(view: View) {
                 if (view is RCTAppodealNativeAssetView) {

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeAdView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeAdView.kt
@@ -190,15 +190,17 @@ class RCTAppodealNativeAdView(context: Context) :
         } catch (_: Exception) {
         }
 
-        // Same wiring as native_ad_view_custom.xml attrs → registerView.
-        // NativeAdView exposes JavaBean setters; from a Kotlin subclass those
-        // must be assigned as properties (setMediaView(...) does not resolve).
-        assets.media?.let { mediaView = it }
-        assets.icon?.let { iconView = it }
-        assets.title?.let { titleView = it }
-        assets.description?.let { descriptionView = it }
-        assets.callToAction?.let { callToActionView = it }
-        assets.attribution?.let { adAttributionView = it }
+        // Bind via Java helper — Appodeal's Kotlin metadata is obfuscated, so
+        // setMediaView / mediaView= are unresolved from a Kotlin subclass.
+        NativeAdViewAssetBinder.bind(
+            this,
+            assets.media,
+            assets.icon,
+            assets.title,
+            assets.description,
+            assets.callToAction,
+            assets.attribution
+        )
 
         val registered = try {
             registerView(ad, placement)

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeAssetView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeAssetView.kt
@@ -1,0 +1,113 @@
+package com.appodeal.rnappodeal
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.TextView
+import com.appodeal.ads.nativead.NativeIconView
+import com.appodeal.ads.nativead.NativeMediaView
+import com.facebook.react.views.text.ReactTextView
+
+/**
+ * Marker view for a single native-ad asset inside [RCTAppodealNativeAdView].
+ *
+ * Mirrors Appodeal Android demo custom layout children:
+ * [NativeMediaView], [NativeIconView], and TextViews for title / body / CTA.
+ */
+class RCTAppodealNativeAssetView(context: Context) : FrameLayout(context) {
+
+    var assetType: String = "title"
+        set(value) {
+            val normalized = value.ifBlank { "title" }
+            if (field == normalized) return
+            field = normalized
+            rebuild()
+        }
+
+    private var content: View? = null
+
+    private val measureAndLayout = Runnable {
+        val w = measuredWidth
+        val h = measuredHeight
+        if (w <= 0 || h <= 0) return@Runnable
+        val child = content ?: return@Runnable
+        child.visibility = VISIBLE
+        child.measure(
+            MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
+        )
+        child.layout(0, 0, child.measuredWidth, child.measuredHeight)
+    }
+
+    init {
+        clipChildren = false
+        clipToPadding = false
+        rebuild()
+    }
+
+    override fun requestLayout() {
+        super.requestLayout()
+        post(measureAndLayout)
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        post(measureAndLayout)
+    }
+
+    fun mediaView(): NativeMediaView? = content as? NativeMediaView
+
+    fun iconView(): NativeIconView? = content as? NativeIconView
+
+    fun textView(): TextView? = content as? TextView
+
+    private fun rebuild() {
+        removeAllViews()
+        val view: View = when (assetType) {
+            "media" -> NativeMediaView(context)
+            "icon" -> NativeIconView(context)
+            else -> ReactTextView(context).apply {
+                when (assetType) {
+                    "callToAction" -> {
+                        setTextColor(0xFFFFFFFF.toInt())
+                        textSize = 12f
+                        gravity = android.view.Gravity.CENTER
+                        maxLines = 1
+                    }
+                    "attribution" -> {
+                        setTextColor(0xFFFFFFFF.toInt())
+                        textSize = 9f
+                        gravity = android.view.Gravity.CENTER
+                        text = "Ad"
+                        maxLines = 1
+                    }
+                    "description" -> {
+                        setTextColor(0xFF7F6D5F.toInt())
+                        textSize = 11f
+                        maxLines = 1
+                    }
+                    else -> {
+                        setTextColor(0xFF2D2424.toInt())
+                        textSize = 13f
+                        maxLines = 2
+                    }
+                }
+            }
+        }
+        content = view
+        addView(
+            view,
+            LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+        post(measureAndLayout)
+        (parent as? RCTAppodealNativeAdView)?.onAssetChanged()
+    }
+
+    companion object {
+        const val NAME = "RNAppodealNativeAssetView"
+    }
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -1,0 +1,124 @@
+package com.appodeal.rnappodeal
+
+import android.content.Context
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import com.appodeal.ads.nativead.NativeAdView
+import com.appodeal.ads.nativead.NativeAdViewAppWall
+import com.appodeal.ads.nativead.NativeAdViewContentStream
+import com.appodeal.ads.nativead.NativeAdViewNewsFeed
+import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandler
+import com.appodeal.rnappodeal.constants.NativeEvents
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
+import com.facebook.react.uimanager.events.EventDispatcher
+import com.facebook.react.views.view.ReactViewGroup
+
+class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppodealEventHandler {
+
+    private val surfaceId: Int by lazy { UIManagerHelper.getSurfaceId(reactContext) }
+
+    var adId: String? = null
+        set(value) {
+            field = value
+            bindAd()
+        }
+
+    var placement: String = "default"
+        set(value) {
+            field = value
+            bindAd()
+        }
+
+    var template: String = "contentStream"
+        set(value) {
+            if (field != value) {
+                field = value
+                recreateNativeAdView()
+            }
+        }
+
+    private var nativeAdView: NativeAdView? = null
+
+    init {
+        recreateNativeAdView()
+    }
+
+    fun cleanup() {
+        nativeAdView?.let { view ->
+            view.unregisterView()
+            view.destroy()
+        }
+        removeAllViews()
+        nativeAdView = null
+    }
+
+    private fun recreateNativeAdView() {
+        cleanup()
+        val view = createNativeAdView()
+        nativeAdView = view
+        view.layoutParams = FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+        addView(view)
+        bindAd()
+    }
+
+    private fun createNativeAdView(): NativeAdView {
+        return when (template) {
+            "newsFeed" -> NativeAdViewNewsFeed(context)
+            "appWall" -> NativeAdViewAppWall(context)
+            else -> NativeAdViewContentStream(context)
+        }
+    }
+
+    private fun bindAd() {
+        val id = adId ?: return
+        val ad = RNAppodealNativeAdStore.get(id) ?: return
+        val view = nativeAdView ?: return
+        view.registerView(ad, placement)
+    }
+
+    override fun handleEvent(event: String, params: WritableMap?) {
+        when (event) {
+            NativeEvents.ON_NATIVE_LOADED -> dispatchFabricEvent(id, NativeEvents.ON_AD_LOADED, params)
+            NativeEvents.ON_NATIVE_FAILED_TO_LOAD -> dispatchFabricEvent(id, NativeEvents.ON_AD_FAILED_TO_LOAD, params)
+            NativeEvents.ON_NATIVE_SHOWN -> dispatchFabricEvent(id, NativeEvents.ON_AD_SHOWN, params)
+            NativeEvents.ON_NATIVE_CLICKED -> dispatchFabricEvent(id, NativeEvents.ON_AD_CLICKED, params)
+            NativeEvents.ON_NATIVE_EXPIRED -> dispatchFabricEvent(id, NativeEvents.ON_AD_EXPIRED, params)
+            else -> Unit
+        }
+    }
+
+    private fun dispatchFabricEvent(
+        viewId: Int,
+        eventName: String,
+        params: WritableMap?
+    ) {
+        val dispatcher: EventDispatcher? =
+            UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewId)
+        dispatcher?.dispatchEvent(OnViewEvent(surfaceId, viewId, eventName, params))
+    }
+
+    private class OnViewEvent(
+        surfaceId: Int,
+        viewId: Int,
+        private val eventNameParam: String,
+        private val payload: WritableMap?
+    ) : Event<OnViewEvent>(surfaceId, viewId) {
+        override fun getEventName(): String = eventNameParam
+        override fun getEventData(): WritableMap? {
+            if (payload == null) return null
+            val copy = Arguments.createMap()
+            copy.merge(payload)
+            return copy
+        }
+    }
+
+    private val reactContext: ReactContext
+        get() = context as ReactContext
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -1,16 +1,22 @@
 package com.appodeal.rnappodeal
 
 import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.util.TypedValue
+import android.view.Gravity
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
 import com.appodeal.ads.NativeAd
 import com.appodeal.ads.nativead.NativeAdView
-import com.appodeal.ads.nativead.NativeAdViewAppWall
-import com.appodeal.ads.nativead.NativeAdViewContentStream
-import com.appodeal.ads.nativead.NativeAdViewNewsFeed
+import com.appodeal.ads.nativead.NativeIconView
+import com.appodeal.ads.nativead.NativeMediaView
 import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandler
 import com.appodeal.rnappodeal.constants.NativeEvents
 import com.facebook.react.bridge.Arguments
@@ -22,13 +28,16 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.view.ReactViewGroup
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.math.roundToInt
 
 /**
- * Hosts an Appodeal native-ad template inside React Native.
+ * Hosts an Appodeal native ad using a **custom** [NativeAdView] layout.
  *
- * ReactViewGroup does not lay out Android children unless we measure them
- * (same pattern as banner/MREC). Templates also need an Activity context so
- * [NativeAd.canShow] / [NativeAdView.registerView] succeed.
+ * Stock templates (ContentStream/etc.) register successfully inside RN but stay
+ * blank / "not visible globally" because ReactViewGroup + template GONE/VISIBLE
+ * + recreate races destroy the view right after bind. Custom asset binding
+ * (title/CTA/media) matches Appodeal's documented custom-layout path and paints
+ * reliably in RN.
  */
 class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppodealEventHandler {
 
@@ -38,31 +47,34 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     var adId: String? = null
         set(value) {
             if (field == value) return
-            unregisterCurrent()
             field = value
-            scheduleBind(0)
+            boundAdId = null
+            bindGeneration++
+            scheduleBind(BIND_DELAY_MS)
         }
 
     var placement: String = "default"
         set(value) {
             if (field == value) return
-            unregisterCurrent()
             field = value
-            scheduleBind(0)
+            if (boundAdId != null) {
+                boundAdId = null
+                bindGeneration++
+                scheduleBind(BIND_DELAY_MS)
+            }
         }
 
+    /** Kept for API compat; custom layout ignores template style. */
+    @Suppress("UNUSED_PARAMETER")
     var adTemplate: String = "contentStream"
-        set(value) {
-            if (field == value) return
-            field = value
-            recreateNativeAdView()
-            scheduleBind(0)
-        }
 
     private var nativeAdView: NativeAdView? = null
+    private var titleView: TextView? = null
+    private var descriptionView: TextView? = null
+    private var ctaView: Button? = null
     private var boundAdId: String? = null
     private var bindRunnable: Runnable? = null
-    private var createdWithActivity: Boolean = false
+    private var bindGeneration: Int = 0
     private var bindAttempts: Int = 0
 
     private val measureAndLayout = Runnable {
@@ -81,7 +93,7 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
     init {
         liveViews.add(WeakReference(this))
-        recreateNativeAdView()
+        ensureNativeAdView()
     }
 
     override fun requestLayout() {
@@ -100,112 +112,204 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     fun cleanup() {
         bindRunnable?.let { uiHandler.removeCallbacks(it) }
         bindRunnable = null
-        unregisterCurrent()
-        nativeAdView?.let { view ->
-            try {
-                view.destroy()
-            } catch (_: Exception) {
-            }
-        }
+        bindGeneration++
+        unbindQuietly()
         removeAllViews()
         nativeAdView = null
+        titleView = null
+        descriptionView = null
+        ctaView = null
         val self = this
         liveViews.removeAll { it.get() == null || it.get() === self }
     }
 
-    /** Called when Activity becomes available (module onHostResume). */
     fun onActivityReady() {
         if (boundAdId == null && !adId.isNullOrEmpty()) {
             scheduleBind(0)
         }
     }
 
-    private fun hostContext(): Context {
+    private fun hostActivityContext(): Context {
         return RNAppodealActivityHolder.get()
             ?: reactContext.currentActivity
             ?: context
     }
 
-    private fun unregisterCurrent() {
-        if (boundAdId != null || nativeAdView != null) {
-            try {
-                nativeAdView?.unregisterView()
-            } catch (_: Exception) {
-            }
-        }
-        boundAdId = null
-        bindAttempts = 0
-    }
-
-    private fun recreateNativeAdView() {
-        unregisterCurrent()
-        nativeAdView?.let { view ->
-            try {
-                view.destroy()
-            } catch (_: Exception) {
-            }
-        }
-        removeAllViews()
-
-        val activity = RNAppodealActivityHolder.get() ?: reactContext.currentActivity
-        createdWithActivity = activity != null
-        val view = createNativeAdView(activity ?: context)
+    private fun ensureNativeAdView() {
+        if (nativeAdView != null) return
+        val view = buildCustomNativeAdView(hostActivityContext())
         nativeAdView = view
-        view.layoutParams = FrameLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.MATCH_PARENT
+        addView(
+            view,
+            LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
         )
-        view.descendantFocusability = FOCUS_BLOCK_DESCENDANTS
-        addView(view)
         post(measureAndLayout)
     }
 
-    private fun createNativeAdView(ctx: Context): NativeAdView {
-        return when (adTemplate) {
-            "newsFeed" -> NativeAdViewNewsFeed(ctx)
-            "appWall" -> NativeAdViewAppWall(ctx)
-            else -> NativeAdViewContentStream(ctx)
+    private fun buildCustomNativeAdView(ctx: Context): NativeAdView {
+        val adView = NativeAdView(ctx)
+        adView.setBackgroundColor(Color.WHITE)
+
+        val root = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.WHITE)
+            setPadding(dpPx(ctx, 8), dpPx(ctx, 8), dpPx(ctx, 8), dpPx(ctx, 8))
         }
+
+        val attribution = TextView(ctx).apply {
+            text = "Ad"
+            setTextColor(Color.WHITE)
+            setBackgroundColor(Color.parseColor("#FF9800"))
+            setPadding(dpPx(ctx, 6), dpPx(ctx, 2), dpPx(ctx, 6), dpPx(ctx, 2))
+            textSize = 10f
+            typeface = Typeface.DEFAULT_BOLD
+        }
+
+        val header = LinearLayout(ctx).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+
+        val icon = NativeIconView(ctx)
+        val iconLp = LinearLayout.LayoutParams(dpPx(ctx, 40), dpPx(ctx, 40)).apply {
+            rightMargin = dpPx(ctx, 8)
+        }
+
+        val title = TextView(ctx).apply {
+            setTextColor(Color.BLACK)
+            textSize = 14f
+            typeface = Typeface.DEFAULT_BOLD
+            maxLines = 2
+        }
+        titleView = title
+
+        header.addView(icon, iconLp)
+        header.addView(
+            title,
+            LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        )
+
+        val description = TextView(ctx).apply {
+            setTextColor(Color.DKGRAY)
+            textSize = 12f
+            maxLines = 3
+        }
+        descriptionView = description
+
+        val media = NativeMediaView(ctx).apply {
+            setBackgroundColor(Color.parseColor("#EEEEEE"))
+        }
+
+        val cta = Button(ctx).apply {
+            isAllCaps = false
+            setTextColor(Color.WHITE)
+            setBackgroundColor(Color.parseColor("#1A73E8"))
+        }
+        ctaView = cta
+
+        root.addView(
+            attribution,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
+        root.addView(
+            header,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = dpPx(ctx, 6) }
+        )
+        root.addView(
+            description,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = dpPx(ctx, 4) }
+        )
+        root.addView(
+            media,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                0,
+                1f
+            ).apply { topMargin = dpPx(ctx, 6) }
+        )
+        root.addView(
+            cta,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = dpPx(ctx, 6) }
+        )
+
+        adView.addView(
+            root,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+
+        adView.setTitleView(title)
+        adView.setDescriptionView(description)
+        adView.setCallToActionView(cta)
+        adView.setIconView(icon)
+        adView.setMediaView(media)
+        adView.setAdAttributionView(attribution)
+
+        return adView
     }
 
     private fun scheduleBind(delayMs: Long) {
         bindRunnable?.let { uiHandler.removeCallbacks(it) }
-        val runnable = Runnable { bindAd() }.also { bindRunnable = it }
+        val gen = bindGeneration
+        val runnable = Runnable {
+            if (gen != bindGeneration) return@Runnable
+            bindAd(gen)
+        }.also { bindRunnable = it }
         uiHandler.postDelayed(runnable, delayMs.coerceAtLeast(0L))
     }
 
-    private fun bindAd() {
+    private fun bindAd(gen: Int) {
+        if (gen != bindGeneration) return
         val id = adId
         if (id.isNullOrEmpty()) return
         if (boundAdId == id) return
 
         val ad: NativeAd = RNAppodealNativeAdStore.get(id) ?: run {
-            Log.w(TAG, "bindAd: no NativeAd in store for id=$id")
-            // Ad may arrive slightly later; retry a few times before failing.
-            if (retryOrFail(id, "native ad not in store")) return
+            if (!retry(gen, id, "native ad not in store")) {
+                dispatchFailed(id, "native ad not in store")
+            }
+            return
+        }
+
+        if (measuredWidth <= 0 || measuredHeight <= 0) {
+            if (!retry(gen, id, "view has zero size")) {
+                dispatchFailed(id, "view has zero size")
+            }
             return
         }
 
         val activity = RNAppodealActivityHolder.get() ?: reactContext.currentActivity
-        if (nativeAdView == null || (activity != null && !createdWithActivity)) {
-            recreateNativeAdView()
+        if (activity == null) {
+            if (!retry(gen, id, "activity unavailable")) {
+                dispatchFailed(id, "activity unavailable")
+            }
+            return
         }
+
+        ensureNativeAdView()
         val view = nativeAdView ?: run {
             dispatchFailed(id, "native ad view missing")
             return
         }
 
-        if (measuredWidth <= 0 || measuredHeight <= 0) {
-            Log.d(TAG, "bindAd: waiting for size id=$id attempt=$bindAttempts")
-            retryOrFail(id, "view has zero size")
-            return
-        }
-
-        if (activity == null) {
-            Log.d(TAG, "bindAd: waiting for Activity id=$id attempt=$bindAttempts")
-            retryOrFail(id, "activity unavailable")
-            return
-        }
+        // Populate assets BEFORE registerView (Appodeal custom-layout contract).
+        titleView?.text = ad.title.orEmpty().ifEmpty { "Ad" }
+        descriptionView?.text = ad.description.orEmpty()
+        ctaView?.text = ad.callToAction.orEmpty().ifEmpty { "Learn more" }
 
         post(measureAndLayout)
 
@@ -216,18 +320,16 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             false
         }
         if (!canShow) {
-            Log.w(TAG, "bindAd: canShow=false id=$id placement=$placement attempt=$bindAttempts")
-            retryOrFail(id, "canShow=false for placement=$placement")
+            if (!retry(gen, id, "canShow=false")) {
+                dispatchFailed(id, "canShow=false for placement=$placement")
+            }
             return
         }
 
-        // Ensure clean registration if something was partially bound.
-        if (boundAdId != null && boundAdId != id) {
-            try {
-                view.unregisterView()
-            } catch (_: Exception) {
-            }
-            boundAdId = null
+        // Do NOT destroy/recreate here — that was wiping a successful register.
+        try {
+            view.unregisterView()
+        } catch (_: Exception) {
         }
 
         val registered = try {
@@ -239,36 +341,47 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
         Log.d(
             TAG,
-            "registerView id=$id placement=$placement result=$registered size=${measuredWidth}x${measuredHeight}"
+            "registerView id=$id result=$registered size=${measuredWidth}x${measuredHeight} title=${ad.title}"
         )
+
+        if (gen != bindGeneration) return
 
         if (registered) {
             boundAdId = id
             bindAttempts = 0
             visibility = VISIBLE
             view.visibility = VISIBLE
-            try {
-                (parent as? ViewGroup)?.bringChildToFront(this)
-            } catch (_: Exception) {
-            }
-            view.bringToFront()
             post(measureAndLayout)
+            // Second layout pass after SDK mutates media children.
+            uiHandler.postDelayed({
+                if (gen == bindGeneration) post(measureAndLayout)
+            }, 100L)
             dispatchLoaded(id)
-        } else {
-            retryOrFail(id, "registerView returned false")
+        } else if (!retry(gen, id, "registerView returned false")) {
+            dispatchFailed(id, "registerView returned false")
         }
     }
 
-    /** @return true if a retry was scheduled */
-    private fun retryOrFail(id: String, reason: String): Boolean {
+    private fun retry(gen: Int, id: String, reason: String): Boolean {
+        if (gen != bindGeneration) return true
         bindAttempts += 1
-        if (bindAttempts <= MAX_BIND_ATTEMPTS) {
-            val delay = BIND_BASE_DELAY_MS * bindAttempts
-            scheduleBind(delay)
-            return true
+        if (bindAttempts > MAX_BIND_ATTEMPTS) return false
+        Log.d(TAG, "retry #$bindAttempts id=$id reason=$reason")
+        scheduleBind(BIND_DELAY_MS * bindAttempts)
+        return true
+    }
+
+    private fun unbindQuietly() {
+        try {
+            nativeAdView?.unregisterView()
+        } catch (_: Exception) {
         }
-        dispatchFailed(id, reason)
-        return false
+        try {
+            nativeAdView?.destroy()
+        } catch (_: Exception) {
+        }
+        boundAdId = null
+        bindAttempts = 0
     }
 
     private fun dispatchLoaded(id: String) {
@@ -286,8 +399,6 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     }
 
     override fun handleEvent(event: String, params: WritableMap?) {
-        // Global SDK callbacks fan out to every view — only forward if this
-        // view is bound, and attach adId when missing.
         when (event) {
             NativeEvents.ON_NATIVE_SHOWN -> {
                 if (boundAdId == null) return
@@ -299,11 +410,13 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             }
             NativeEvents.ON_NATIVE_EXPIRED -> {
                 if (boundAdId == null) return
-                unregisterCurrent()
-                visibility = GONE
+                try {
+                    nativeAdView?.unregisterView()
+                } catch (_: Exception) {
+                }
+                boundAdId = null
                 dispatchFabricEvent(getId(), NativeEvents.ON_AD_EXPIRED, withAdId(params))
             }
-            // Cache-level load events are not per-view bind results — ignore here.
             else -> Unit
         }
     }
@@ -311,18 +424,12 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     private fun withAdId(params: WritableMap?): WritableMap {
         val copy = Arguments.createMap()
         if (params != null) copy.merge(params)
-        if (!copy.hasKey("adId")) {
-            copy.putString("adId", boundAdId ?: adId)
-        }
+        if (!copy.hasKey("adId")) copy.putString("adId", boundAdId ?: adId)
         return copy
     }
 
-    private fun dispatchFabricEvent(
-        viewId: Int,
-        eventName: String,
-        params: WritableMap?
-    ) {
-        val dispatcher: EventDispatcher? =
+    private fun dispatchFabricEvent(viewId: Int, eventName: String, params: WritableMap?) {
+        val dispatcher =
             UIManagerHelper.getEventDispatcherForReactTag(reactContext, viewId)
         dispatcher?.dispatchEvent(OnViewEvent(surfaceId, viewId, eventName, params))
     }
@@ -347,34 +454,40 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
     companion object {
         private const val TAG = "RNAppodealNative"
-        private const val MAX_BIND_ATTEMPTS = 8
-        private const val BIND_BASE_DELAY_MS = 250L
+        private const val MAX_BIND_ATTEMPTS = 6
+        private const val BIND_DELAY_MS = 200L
 
         private val liveViews = CopyOnWriteArrayList<WeakReference<RCTAppodealNativeView>>()
 
         fun notifyActivityReady() {
-            pruneLiveViews()
-            for (ref in liveViews) {
-                ref.get()?.onActivityReady()
-            }
+            prune()
+            for (ref in liveViews) ref.get()?.onActivityReady()
         }
 
         fun unbindAdId(adId: String) {
-            pruneLiveViews()
+            prune()
             for (ref in liveViews) {
                 val view = ref.get() ?: continue
                 if (view.adId == adId || view.boundAdId == adId) {
-                    view.unregisterCurrent()
-                    view.visibility = GONE
+                    view.bindGeneration++
+                    try {
+                        view.nativeAdView?.unregisterView()
+                    } catch (_: Exception) {
+                    }
+                    view.boundAdId = null
                 }
             }
         }
 
-        private fun pruneLiveViews() {
-            val it = liveViews.iterator()
-            while (it.hasNext()) {
-                if (it.next().get() == null) it.remove()
-            }
+        private fun prune() {
+            liveViews.removeAll { it.get() == null }
         }
     }
 }
+
+private fun dpPx(ctx: Context, value: Int): Int =
+    TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        value.toFloat(),
+        ctx.resources.displayMetrics
+    ).roundToInt()

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -1,8 +1,12 @@
 package com.appodeal.rnappodeal
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import com.appodeal.ads.NativeAd
 import com.appodeal.ads.nativead.NativeAdView
 import com.appodeal.ads.nativead.NativeAdViewAppWall
 import com.appodeal.ads.nativead.NativeAdViewContentStream
@@ -17,76 +21,208 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.view.ReactViewGroup
 
+/**
+ * Hosts an Appodeal native-ad template inside React Native.
+ *
+ * Important: ReactViewGroup does not lay out Android children unless we
+ * explicitly measure/layout them (same pattern as banner/MREC). Templates
+ * also need an Activity context so [NativeAd.canShow] / [NativeAdView.registerView]
+ * succeed — ReactContext alone often makes registerView return false and the
+ * template stays GONE.
+ */
 class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppodealEventHandler {
 
     private val surfaceId: Int by lazy { UIManagerHelper.getSurfaceId(reactContext) }
+    private val uiHandler: Handler by lazy { Handler(Looper.getMainLooper()) }
 
     var adId: String? = null
         set(value) {
+            if (field == value) return
             field = value
-            bindAd()
+            boundAdId = null
+            scheduleBind()
         }
 
     var placement: String = "default"
         set(value) {
+            if (field == value) return
             field = value
-            bindAd()
+            boundAdId = null
+            scheduleBind()
         }
 
     var adTemplate: String = "contentStream"
         set(value) {
-            if (field != value) {
-                field = value
-                recreateNativeAdView()
-            }
+            if (field == value) return
+            field = value
+            boundAdId = null
+            recreateNativeAdView()
+            scheduleBind()
         }
 
     private var nativeAdView: NativeAdView? = null
+    private var boundAdId: String? = null
+    private var bindRunnable: Runnable? = null
+    /** True when the template was constructed with an Activity (needed for canShow). */
+    private var createdWithActivity: Boolean = false
+
+    /**
+     * Mirror banner/MREC: RN won't size native children without this.
+     */
+    private val measureAndLayout = Runnable {
+        val w = measuredWidth
+        val h = measuredHeight
+        if (w <= 0 || h <= 0) return@Runnable
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+            child.measure(
+                MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
+            )
+            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
+        }
+    }
 
     init {
         recreateNativeAdView()
     }
 
+    override fun requestLayout() {
+        super.requestLayout()
+        post(measureAndLayout)
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        post(measureAndLayout)
+        if (right - left > 0 && bottom - top > 0) {
+            scheduleBind()
+        }
+    }
+
     fun cleanup() {
+        bindRunnable?.let { uiHandler.removeCallbacks(it) }
+        bindRunnable = null
         nativeAdView?.let { view ->
-            view.unregisterView()
-            view.destroy()
+            try {
+                view.unregisterView()
+            } catch (_: Exception) {
+            }
+            try {
+                view.destroy()
+            } catch (_: Exception) {
+            }
         }
         removeAllViews()
         nativeAdView = null
+        boundAdId = null
+    }
+
+    private fun hostContext(): Context {
+        return reactContext.currentActivity ?: context
     }
 
     private fun recreateNativeAdView() {
-        cleanup()
-        val view = createNativeAdView()
+        nativeAdView?.let { view ->
+            try {
+                view.unregisterView()
+            } catch (_: Exception) {
+            }
+            try {
+                view.destroy()
+            } catch (_: Exception) {
+            }
+        }
+        removeAllViews()
+        boundAdId = null
+
+        val host = hostContext()
+        createdWithActivity = reactContext.currentActivity != null
+        val view = createNativeAdView(host)
         nativeAdView = view
         view.layoutParams = FrameLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT
+            ViewGroup.LayoutParams.MATCH_PARENT
         )
+        // Templates start GONE until registerView succeeds.
         addView(view)
-        bindAd()
+        post(measureAndLayout)
     }
 
-    private fun createNativeAdView(): NativeAdView {
+    private fun createNativeAdView(ctx: Context): NativeAdView {
         return when (adTemplate) {
-            "newsFeed" -> NativeAdViewNewsFeed(context)
-            "appWall" -> NativeAdViewAppWall(context)
-            else -> NativeAdViewContentStream(context)
+            "newsFeed" -> NativeAdViewNewsFeed(ctx)
+            "appWall" -> NativeAdViewAppWall(ctx)
+            else -> NativeAdViewContentStream(ctx)
         }
     }
 
+    private fun scheduleBind() {
+        bindRunnable?.let { uiHandler.removeCallbacks(it) }
+        val runnable = Runnable { bindAd() }.also { bindRunnable = it }
+        // Slight delay so RN has committed size (same idea as banner show).
+        uiHandler.postDelayed(runnable, 50L)
+    }
+
     private fun bindAd() {
-        val id = adId ?: return
-        val ad = RNAppodealNativeAdStore.get(id) ?: return
+        val id = adId
+        if (id.isNullOrEmpty()) return
+        if (boundAdId == id) return
+
+        val ad: NativeAd = RNAppodealNativeAdStore.get(id) ?: run {
+            Log.w(TAG, "bindAd: no NativeAd in store for id=$id")
+            return
+        }
+
+        // Prefer Activity context — ReactContext alone often makes canShow/registerView fail.
+        if (nativeAdView == null || (reactContext.currentActivity != null && !createdWithActivity)) {
+            recreateNativeAdView()
+        }
         val view = nativeAdView ?: return
-        view.registerView(ad, placement)
+
+        if (measuredWidth <= 0 || measuredHeight <= 0) {
+            Log.d(TAG, "bindAd: waiting for size id=$id")
+            return
+        }
+
+        post(measureAndLayout)
+
+        val canShow = try {
+            ad.canShow(hostContext(), placement)
+        } catch (e: Exception) {
+            Log.e(TAG, "canShow threw", e)
+            false
+        }
+        if (!canShow) {
+            Log.w(TAG, "bindAd: canShow=false id=$id placement=$placement")
+            return
+        }
+
+        val registered = try {
+            view.registerView(ad, placement)
+        } catch (e: Exception) {
+            Log.e(TAG, "registerView threw", e)
+            false
+        }
+
+        Log.d(
+            TAG,
+            "registerView id=$id placement=$placement result=$registered size=${measuredWidth}x${measuredHeight}"
+        )
+
+        if (registered) {
+            boundAdId = id
+            visibility = VISIBLE
+            view.visibility = VISIBLE
+            post(measureAndLayout)
+        }
     }
 
     override fun handleEvent(event: String, params: WritableMap?) {
         when (event) {
             NativeEvents.ON_NATIVE_LOADED -> dispatchFabricEvent(id, NativeEvents.ON_AD_LOADED, params)
-            NativeEvents.ON_NATIVE_FAILED_TO_LOAD -> dispatchFabricEvent(id, NativeEvents.ON_AD_FAILED_TO_LOAD, params)
+            NativeEvents.ON_NATIVE_FAILED_TO_LOAD ->
+                dispatchFabricEvent(id, NativeEvents.ON_AD_FAILED_TO_LOAD, params)
             NativeEvents.ON_NATIVE_SHOWN -> dispatchFabricEvent(id, NativeEvents.ON_AD_SHOWN, params)
             NativeEvents.ON_NATIVE_CLICKED -> dispatchFabricEvent(id, NativeEvents.ON_AD_CLICKED, params)
             NativeEvents.ON_NATIVE_EXPIRED -> dispatchFabricEvent(id, NativeEvents.ON_AD_EXPIRED, params)
@@ -121,4 +257,8 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
     private val reactContext: ReactContext
         get() = context as ReactContext
+
+    companion object {
+        private const val TAG = "RNAppodealNative"
+    }
 }

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -6,8 +6,12 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import com.appodeal.ads.NativeAd
+import com.appodeal.ads.nativead.NativeAdView
+import com.appodeal.ads.nativead.NativeAdViewAppWall
 import com.appodeal.ads.nativead.NativeAdViewContentStream
+import com.appodeal.ads.nativead.NativeAdViewNewsFeed
 import com.appodeal.ads.nativead.Position
 import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandler
 import com.appodeal.rnappodeal.constants.NativeEvents
@@ -20,21 +24,19 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
- * React Native host for Appodeal native ads.
+ * RN host for Appodeal native ads.
  *
- * Matches the official Appodeal Android demo
- * (`appodeal/appodeal-android-sdk` → `NativeListAdapter` / `NativeActivity`):
- * the list item **is** a [NativeAdViewContentStream], then `registerView(nativeAd)`.
+ * [NativeAdViewContentStream] / templates are **final** — cannot subclass.
+ * Official Android demo uses the template as the RecyclerView item root.
+ * Here we mirror the working banner bridge: always-VISIBLE [FrameLayout] host,
+ * template as MATCH_PARENT child, then [NativeAdView.registerView].
  *
- * Previous approach nested a GONE-by-default [com.appodeal.ads.nativead.NativeAdView]
- * inside [com.facebook.react.views.view.ReactViewGroup]. `registerView` returned true
- * but the child stayed absent from the UI hierarchy (uiautomator: empty host), while
- * banners (VISIBLE [com.appodeal.ads.BannerView] child) rendered fine.
+ * Critical: templates default to GONE. Banner works because [com.appodeal.ads.BannerView]
+ * is VISIBLE before addView. We force the same.
  */
-class RCTAppodealNativeView(
-    private val reactContext: ReactContext
-) : NativeAdViewContentStream(reactContext), RNAppodealEventHandler {
+class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodealEventHandler {
 
+    private val reactContext: ReactContext = context as ReactContext
     private val surfaceId: Int by lazy { UIManagerHelper.getSurfaceId(reactContext) }
     private val uiHandler: Handler by lazy { Handler(Looper.getMainLooper()) }
 
@@ -58,10 +60,19 @@ class RCTAppodealNativeView(
             }
         }
 
-    /** Kept for API compat; ContentStream template is fixed (matches Android demo default). */
-    @Suppress("UNUSED_PARAMETER")
     var adTemplate: String = "contentStream"
+        set(value) {
+            val normalized = value.ifBlank { "contentStream" }
+            if (field == normalized) return
+            field = normalized
+            // Template class change requires a new child instance.
+            tearDownAdView()
+            boundAdId = null
+            bindGeneration++
+            scheduleBind(BIND_DELAY_MS)
+        }
 
+    private var adView: NativeAdView? = null
     private var boundAdId: String? = null
     private var bindRunnable: Runnable? = null
     private var bindGeneration: Int = 0
@@ -69,27 +80,18 @@ class RCTAppodealNativeView(
 
     init {
         liveViews.add(WeakReference(this))
-        // Demo XML starts templates as gone; RN must keep a real laid-out host so
-        // Appodeal's viewability check can pass. Force visible like BannerView hosts.
         visibility = VISIBLE
-        descendantFocusability = FOCUS_BLOCK_DESCENDANTS
         setBackgroundColor(Color.WHITE)
-        setAdChoicesPosition(Position.END_TOP)
-        contentDescription = "appodeal-native-ad"
+        contentDescription = "appodeal-native-host"
+        clipChildren = false
+        clipToPadding = false
     }
 
     fun cleanup() {
         bindRunnable?.let { uiHandler.removeCallbacks(it) }
         bindRunnable = null
         bindGeneration++
-        try {
-            unregisterView()
-        } catch (_: Exception) {
-        }
-        try {
-            destroy()
-        } catch (_: Exception) {
-        }
+        tearDownAdView()
         boundAdId = null
         bindAttempts = 0
         val self = this
@@ -113,6 +115,66 @@ class RCTAppodealNativeView(
         super.onAttachedToWindow()
         if (boundAdId == null && !adId.isNullOrEmpty()) {
             scheduleBind(0)
+        }
+    }
+
+    private fun tearDownAdView() {
+        val view = adView
+        adView = null
+        if (view != null) {
+            try {
+                view.unregisterView()
+            } catch (_: Exception) {
+            }
+            try {
+                view.destroy()
+            } catch (_: Exception) {
+            }
+            (view.parent as? ViewGroup)?.removeView(view)
+        }
+        removeAllViews()
+    }
+
+    /**
+     * Same attach sequence as [RCTAppodealBannerView.showBannerView]:
+     * VISIBLE → layout params → removeAllViews → addView → bringToFront.
+     */
+    private fun ensureAdView(): NativeAdView {
+        adView?.let { existing ->
+            existing.visibility = VISIBLE
+            return existing
+        }
+
+        val view = createTemplate(adTemplate).apply {
+            // Templates default to GONE — that was the blank-card root cause.
+            visibility = VISIBLE
+            descendantFocusability = FOCUS_BLOCK_DESCENDANTS
+            setAdChoicesPosition(Position.END_TOP)
+            contentDescription = "appodeal-native-ad"
+            layoutParams = LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        }
+
+        removeAllViews()
+        this.visibility = VISIBLE
+        addView(view)
+        view.bringToFront()
+        try {
+            (parent as? ViewGroup)?.bringChildToFront(this)
+        } catch (_: Exception) {
+        }
+
+        adView = view
+        return view
+    }
+
+    private fun createTemplate(template: String): NativeAdView {
+        return when (template) {
+            "newsFeed" -> NativeAdViewNewsFeed(context)
+            "appWall" -> NativeAdViewAppWall(context)
+            else -> NativeAdViewContentStream(context)
         }
     }
 
@@ -174,33 +236,32 @@ class RCTAppodealNativeView(
             return
         }
 
-        // Same sequence as NativeActivity.showNative / NativeListAdapter.bind:
-        // configure → registerView(nativeAd). Do not destroy/recreate between binds.
+        val view = ensureAdView()
+        view.visibility = VISIBLE
+
         try {
-            unregisterView()
+            view.unregisterView()
         } catch (_: Exception) {
         }
 
-        visibility = VISIBLE
-
         val registered = try {
-            registerView(ad, placement)
+            view.registerView(ad, placement)
         } catch (e: Exception) {
             Log.e(TAG, "registerView threw", e)
             false
         }
 
-        // SDK flips GONE→VISIBLE on success; keep forcing VISIBLE for RN hosts.
-        visibility = VISIBLE
-        bringToFront()
-        (parent as? ViewGroup)?.bringChildToFront(this)
+        view.visibility = VISIBLE
+        this.visibility = VISIBLE
+        view.bringToFront()
         requestLayout()
         invalidate()
 
         Log.d(
             TAG,
-            "registerView id=$id result=$registered size=${width}x${height} " +
-                "vis=$visibility attached=$isAttachedToWindow title=${ad.title}"
+            "registerView id=$id result=$registered host=${width}x${height} " +
+                "childCount=$childCount childVis=${view.visibility} " +
+                "attached=$isAttachedToWindow title=${ad.title}"
         )
 
         if (gen != bindGeneration) return
@@ -210,11 +271,13 @@ class RCTAppodealNativeView(
             bindAttempts = 0
             uiHandler.postDelayed({
                 if (gen != bindGeneration) return@postDelayed
-                visibility = VISIBLE
+                view.visibility = VISIBLE
+                this.visibility = VISIBLE
                 requestLayout()
                 Log.d(
                     TAG,
-                    "post-bind childCount=$childCount size=${width}x${height} vis=$visibility"
+                    "post-bind childCount=$childCount childVis=${view.visibility} " +
+                        "childSize=${view.width}x${view.height}"
                 )
             }, 100L)
             dispatchLoaded(id)
@@ -259,7 +322,7 @@ class RCTAppodealNativeView(
             NativeEvents.ON_NATIVE_EXPIRED -> {
                 if (boundAdId == null) return
                 try {
-                    unregisterView()
+                    adView?.unregisterView()
                 } catch (_: Exception) {
                 }
                 boundAdId = null
@@ -316,7 +379,7 @@ class RCTAppodealNativeView(
                 if (view.adId == adId || view.boundAdId == adId) {
                     view.bindGeneration++
                     try {
-                        view.unregisterView()
+                        view.adView?.unregisterView()
                     } catch (_: Exception) {
                     }
                     view.boundAdId = null

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -20,15 +20,15 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.view.ReactViewGroup
+import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Hosts an Appodeal native-ad template inside React Native.
  *
- * Important: ReactViewGroup does not lay out Android children unless we
- * explicitly measure/layout them (same pattern as banner/MREC). Templates
- * also need an Activity context so [NativeAd.canShow] / [NativeAdView.registerView]
- * succeed — ReactContext alone often makes registerView return false and the
- * template stays GONE.
+ * ReactViewGroup does not lay out Android children unless we measure them
+ * (same pattern as banner/MREC). Templates also need an Activity context so
+ * [NativeAd.canShow] / [NativeAdView.registerView] succeed.
  */
 class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppodealEventHandler {
 
@@ -38,37 +38,33 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     var adId: String? = null
         set(value) {
             if (field == value) return
+            unregisterCurrent()
             field = value
-            boundAdId = null
-            scheduleBind()
+            scheduleBind(0)
         }
 
     var placement: String = "default"
         set(value) {
             if (field == value) return
+            unregisterCurrent()
             field = value
-            boundAdId = null
-            scheduleBind()
+            scheduleBind(0)
         }
 
     var adTemplate: String = "contentStream"
         set(value) {
             if (field == value) return
             field = value
-            boundAdId = null
             recreateNativeAdView()
-            scheduleBind()
+            scheduleBind(0)
         }
 
     private var nativeAdView: NativeAdView? = null
     private var boundAdId: String? = null
     private var bindRunnable: Runnable? = null
-    /** True when the template was constructed with an Activity (needed for canShow). */
     private var createdWithActivity: Boolean = false
+    private var bindAttempts: Int = 0
 
-    /**
-     * Mirror banner/MREC: RN won't size native children without this.
-     */
     private val measureAndLayout = Runnable {
         val w = measuredWidth
         val h = measuredHeight
@@ -84,6 +80,7 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     }
 
     init {
+        liveViews.add(WeakReference(this))
         recreateNativeAdView()
     }
 
@@ -95,19 +92,16 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         super.onLayout(changed, left, top, right, bottom)
         post(measureAndLayout)
-        if (right - left > 0 && bottom - top > 0) {
-            scheduleBind()
+        if (right - left > 0 && bottom - top > 0 && boundAdId == null && !adId.isNullOrEmpty()) {
+            scheduleBind(0)
         }
     }
 
     fun cleanup() {
         bindRunnable?.let { uiHandler.removeCallbacks(it) }
         bindRunnable = null
+        unregisterCurrent()
         nativeAdView?.let { view ->
-            try {
-                view.unregisterView()
-            } catch (_: Exception) {
-            }
             try {
                 view.destroy()
             } catch (_: Exception) {
@@ -115,36 +109,53 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         }
         removeAllViews()
         nativeAdView = null
-        boundAdId = null
+        val self = this
+        liveViews.removeAll { it.get() == null || it.get() === self }
+    }
+
+    /** Called when Activity becomes available (module onHostResume). */
+    fun onActivityReady() {
+        if (boundAdId == null && !adId.isNullOrEmpty()) {
+            scheduleBind(0)
+        }
     }
 
     private fun hostContext(): Context {
-        return reactContext.currentActivity ?: context
+        return RNAppodealActivityHolder.get()
+            ?: reactContext.currentActivity
+            ?: context
+    }
+
+    private fun unregisterCurrent() {
+        if (boundAdId != null || nativeAdView != null) {
+            try {
+                nativeAdView?.unregisterView()
+            } catch (_: Exception) {
+            }
+        }
+        boundAdId = null
+        bindAttempts = 0
     }
 
     private fun recreateNativeAdView() {
+        unregisterCurrent()
         nativeAdView?.let { view ->
-            try {
-                view.unregisterView()
-            } catch (_: Exception) {
-            }
             try {
                 view.destroy()
             } catch (_: Exception) {
             }
         }
         removeAllViews()
-        boundAdId = null
 
-        val host = hostContext()
-        createdWithActivity = reactContext.currentActivity != null
-        val view = createNativeAdView(host)
+        val activity = RNAppodealActivityHolder.get() ?: reactContext.currentActivity
+        createdWithActivity = activity != null
+        val view = createNativeAdView(activity ?: context)
         nativeAdView = view
         view.layoutParams = FrameLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT
         )
-        // Templates start GONE until registerView succeeds.
+        view.descendantFocusability = FOCUS_BLOCK_DESCENDANTS
         addView(view)
         post(measureAndLayout)
     }
@@ -157,11 +168,10 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         }
     }
 
-    private fun scheduleBind() {
+    private fun scheduleBind(delayMs: Long) {
         bindRunnable?.let { uiHandler.removeCallbacks(it) }
         val runnable = Runnable { bindAd() }.also { bindRunnable = it }
-        // Slight delay so RN has committed size (same idea as banner show).
-        uiHandler.postDelayed(runnable, 50L)
+        uiHandler.postDelayed(runnable, delayMs.coerceAtLeast(0L))
     }
 
     private fun bindAd() {
@@ -171,31 +181,53 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
         val ad: NativeAd = RNAppodealNativeAdStore.get(id) ?: run {
             Log.w(TAG, "bindAd: no NativeAd in store for id=$id")
+            // Ad may arrive slightly later; retry a few times before failing.
+            if (retryOrFail(id, "native ad not in store")) return
             return
         }
 
-        // Prefer Activity context — ReactContext alone often makes canShow/registerView fail.
-        if (nativeAdView == null || (reactContext.currentActivity != null && !createdWithActivity)) {
+        val activity = RNAppodealActivityHolder.get() ?: reactContext.currentActivity
+        if (nativeAdView == null || (activity != null && !createdWithActivity)) {
             recreateNativeAdView()
         }
-        val view = nativeAdView ?: return
+        val view = nativeAdView ?: run {
+            dispatchFailed(id, "native ad view missing")
+            return
+        }
 
         if (measuredWidth <= 0 || measuredHeight <= 0) {
-            Log.d(TAG, "bindAd: waiting for size id=$id")
+            Log.d(TAG, "bindAd: waiting for size id=$id attempt=$bindAttempts")
+            retryOrFail(id, "view has zero size")
+            return
+        }
+
+        if (activity == null) {
+            Log.d(TAG, "bindAd: waiting for Activity id=$id attempt=$bindAttempts")
+            retryOrFail(id, "activity unavailable")
             return
         }
 
         post(measureAndLayout)
 
         val canShow = try {
-            ad.canShow(hostContext(), placement)
+            ad.canShow(activity, placement)
         } catch (e: Exception) {
             Log.e(TAG, "canShow threw", e)
             false
         }
         if (!canShow) {
-            Log.w(TAG, "bindAd: canShow=false id=$id placement=$placement")
+            Log.w(TAG, "bindAd: canShow=false id=$id placement=$placement attempt=$bindAttempts")
+            retryOrFail(id, "canShow=false for placement=$placement")
             return
+        }
+
+        // Ensure clean registration if something was partially bound.
+        if (boundAdId != null && boundAdId != id) {
+            try {
+                view.unregisterView()
+            } catch (_: Exception) {
+            }
+            boundAdId = null
         }
 
         val registered = try {
@@ -212,22 +244,77 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
         if (registered) {
             boundAdId = id
+            bindAttempts = 0
             visibility = VISIBLE
             view.visibility = VISIBLE
+            try {
+                (parent as? ViewGroup)?.bringChildToFront(this)
+            } catch (_: Exception) {
+            }
+            view.bringToFront()
             post(measureAndLayout)
+            dispatchLoaded(id)
+        } else {
+            retryOrFail(id, "registerView returned false")
         }
     }
 
+    /** @return true if a retry was scheduled */
+    private fun retryOrFail(id: String, reason: String): Boolean {
+        bindAttempts += 1
+        if (bindAttempts <= MAX_BIND_ATTEMPTS) {
+            val delay = BIND_BASE_DELAY_MS * bindAttempts
+            scheduleBind(delay)
+            return true
+        }
+        dispatchFailed(id, reason)
+        return false
+    }
+
+    private fun dispatchLoaded(id: String) {
+        val params = Arguments.createMap().apply { putString("adId", id) }
+        dispatchFabricEvent(getId(), NativeEvents.ON_AD_LOADED, params)
+    }
+
+    private fun dispatchFailed(id: String, message: String) {
+        Log.w(TAG, "bind failed id=$id message=$message")
+        val params = Arguments.createMap().apply {
+            putString("adId", id)
+            putString("message", message)
+        }
+        dispatchFabricEvent(getId(), NativeEvents.ON_AD_FAILED_TO_LOAD, params)
+    }
+
     override fun handleEvent(event: String, params: WritableMap?) {
+        // Global SDK callbacks fan out to every view — only forward if this
+        // view is bound, and attach adId when missing.
         when (event) {
-            NativeEvents.ON_NATIVE_LOADED -> dispatchFabricEvent(id, NativeEvents.ON_AD_LOADED, params)
-            NativeEvents.ON_NATIVE_FAILED_TO_LOAD ->
-                dispatchFabricEvent(id, NativeEvents.ON_AD_FAILED_TO_LOAD, params)
-            NativeEvents.ON_NATIVE_SHOWN -> dispatchFabricEvent(id, NativeEvents.ON_AD_SHOWN, params)
-            NativeEvents.ON_NATIVE_CLICKED -> dispatchFabricEvent(id, NativeEvents.ON_AD_CLICKED, params)
-            NativeEvents.ON_NATIVE_EXPIRED -> dispatchFabricEvent(id, NativeEvents.ON_AD_EXPIRED, params)
+            NativeEvents.ON_NATIVE_SHOWN -> {
+                if (boundAdId == null) return
+                dispatchFabricEvent(getId(), NativeEvents.ON_AD_SHOWN, withAdId(params))
+            }
+            NativeEvents.ON_NATIVE_CLICKED -> {
+                if (boundAdId == null) return
+                dispatchFabricEvent(getId(), NativeEvents.ON_AD_CLICKED, withAdId(params))
+            }
+            NativeEvents.ON_NATIVE_EXPIRED -> {
+                if (boundAdId == null) return
+                unregisterCurrent()
+                visibility = GONE
+                dispatchFabricEvent(getId(), NativeEvents.ON_AD_EXPIRED, withAdId(params))
+            }
+            // Cache-level load events are not per-view bind results — ignore here.
             else -> Unit
         }
+    }
+
+    private fun withAdId(params: WritableMap?): WritableMap {
+        val copy = Arguments.createMap()
+        if (params != null) copy.merge(params)
+        if (!copy.hasKey("adId")) {
+            copy.putString("adId", boundAdId ?: adId)
+        }
+        return copy
     }
 
     private fun dispatchFabricEvent(
@@ -260,5 +347,34 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
     companion object {
         private const val TAG = "RNAppodealNative"
+        private const val MAX_BIND_ATTEMPTS = 8
+        private const val BIND_BASE_DELAY_MS = 250L
+
+        private val liveViews = CopyOnWriteArrayList<WeakReference<RCTAppodealNativeView>>()
+
+        fun notifyActivityReady() {
+            pruneLiveViews()
+            for (ref in liveViews) {
+                ref.get()?.onActivityReady()
+            }
+        }
+
+        fun unbindAdId(adId: String) {
+            pruneLiveViews()
+            for (ref in liveViews) {
+                val view = ref.get() ?: continue
+                if (view.adId == adId || view.boundAdId == adId) {
+                    view.unregisterCurrent()
+                    view.visibility = GONE
+                }
+            }
+        }
+
+        private fun pruneLiveViews() {
+            val it = liveViews.iterator()
+            while (it.hasNext()) {
+                if (it.next().get() == null) it.remove()
+            }
+        }
     }
 }

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -20,21 +20,20 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
+import com.facebook.react.views.view.ReactViewGroup
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * RN host for Appodeal native ads.
  *
- * [NativeAdViewContentStream] / templates are **final** — cannot subclass.
- * Official Android demo uses the template as the RecyclerView item root.
- * Here we mirror the working banner bridge: always-VISIBLE [FrameLayout] host,
- * template as MATCH_PARENT child, then [NativeAdView.registerView].
+ * Templates are final (cannot subclass). Host mirrors the working banner bridge:
+ * [ReactViewGroup] + VISIBLE template child + manual [measureAndLayout].
  *
- * Critical: templates default to GONE. Banner works because [com.appodeal.ads.BannerView]
- * is VISIBLE before addView. We force the same.
+ * Without measureAndLayout, registerView succeeds but the child stays 0×0
+ * (`childSize=0x0`) and Appodeal logs "ad not visible globally".
  */
-class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodealEventHandler {
+class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppodealEventHandler {
 
     private val reactContext: ReactContext = context as ReactContext
     private val surfaceId: Int by lazy { UIManagerHelper.getSurfaceId(reactContext) }
@@ -65,7 +64,6 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
             val normalized = value.ifBlank { "contentStream" }
             if (field == normalized) return
             field = normalized
-            // Template class change requires a new child instance.
             tearDownAdView()
             boundAdId = null
             bindGeneration++
@@ -78,6 +76,22 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
     private var bindGeneration: Int = 0
     private var bindAttempts: Int = 0
 
+    /** Same as banner/MREC — RN will not size native children otherwise. */
+    private val measureAndLayout = Runnable {
+        val w = measuredWidth
+        val h = measuredHeight
+        if (w <= 0 || h <= 0) return@Runnable
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+            child.visibility = VISIBLE
+            child.measure(
+                MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
+            )
+            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
+        }
+    }
+
     init {
         liveViews.add(WeakReference(this))
         visibility = VISIBLE
@@ -85,6 +99,26 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
         contentDescription = "appodeal-native-host"
         clipChildren = false
         clipToPadding = false
+    }
+
+    override fun requestLayout() {
+        super.requestLayout()
+        post(measureAndLayout)
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        post(measureAndLayout)
+        if (right - left > 0 && bottom - top > 0 && boundAdId == null && !adId.isNullOrEmpty()) {
+            scheduleBind(0)
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (boundAdId == null && !adId.isNullOrEmpty()) {
+            scheduleBind(0)
+        }
     }
 
     fun cleanup() {
@@ -99,20 +133,6 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
     }
 
     fun onActivityReady() {
-        if (boundAdId == null && !adId.isNullOrEmpty()) {
-            scheduleBind(0)
-        }
-    }
-
-    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-        super.onLayout(changed, left, top, right, bottom)
-        if (right - left > 0 && bottom - top > 0 && boundAdId == null && !adId.isNullOrEmpty()) {
-            scheduleBind(0)
-        }
-    }
-
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
         if (boundAdId == null && !adId.isNullOrEmpty()) {
             scheduleBind(0)
         }
@@ -135,23 +155,20 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
         removeAllViews()
     }
 
-    /**
-     * Same attach sequence as [RCTAppodealBannerView.showBannerView]:
-     * VISIBLE → layout params → removeAllViews → addView → bringToFront.
-     */
     private fun ensureAdView(): NativeAdView {
         adView?.let { existing ->
             existing.visibility = VISIBLE
+            post(measureAndLayout)
             return existing
         }
 
         val view = createTemplate(adTemplate).apply {
-            // Templates default to GONE — that was the blank-card root cause.
+            // Templates default to GONE — force VISIBLE like BannerView.
             visibility = VISIBLE
             descendantFocusability = FOCUS_BLOCK_DESCENDANTS
             setAdChoicesPosition(Position.END_TOP)
             contentDescription = "appodeal-native-ad"
-            layoutParams = LayoutParams(
+            layoutParams = FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT
             )
@@ -165,6 +182,7 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
             (parent as? ViewGroup)?.bringChildToFront(this)
         } catch (_: Exception) {
         }
+        post(measureAndLayout)
 
         adView = view
         return view
@@ -201,7 +219,7 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
             return
         }
 
-        if (width <= 0 || height <= 0) {
+        if (measuredWidth <= 0 || measuredHeight <= 0) {
             if (!retry(gen, id, "view has zero size")) {
                 dispatchFailed(id, "view has zero size")
             }
@@ -236,8 +254,17 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
             return
         }
 
+        // Size the child BEFORE registerView so viewability can pass.
         val view = ensureAdView()
         view.visibility = VISIBLE
+        runMeasureAndLayoutNow()
+
+        if (view.width <= 0 || view.height <= 0) {
+            if (!retry(gen, id, "child still 0x0 after layout")) {
+                dispatchFailed(id, "child still 0x0 after layout")
+            }
+            return
+        }
 
         try {
             view.unregisterView()
@@ -253,15 +280,13 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
 
         view.visibility = VISIBLE
         this.visibility = VISIBLE
-        view.bringToFront()
-        requestLayout()
-        invalidate()
+        runMeasureAndLayoutNow()
 
         Log.d(
             TAG,
-            "registerView id=$id result=$registered host=${width}x${height} " +
+            "registerView id=$id result=$registered host=${measuredWidth}x${measuredHeight} " +
                 "childCount=$childCount childVis=${view.visibility} " +
-                "attached=$isAttachedToWindow title=${ad.title}"
+                "childSize=${view.width}x${view.height} title=${ad.title}"
         )
 
         if (gen != bindGeneration) return
@@ -272,8 +297,7 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
             uiHandler.postDelayed({
                 if (gen != bindGeneration) return@postDelayed
                 view.visibility = VISIBLE
-                this.visibility = VISIBLE
-                requestLayout()
+                runMeasureAndLayoutNow()
                 Log.d(
                     TAG,
                     "post-bind childCount=$childCount childVis=${view.visibility} " +
@@ -283,6 +307,21 @@ class RCTAppodealNativeView(context: Context) : FrameLayout(context), RNAppodeal
             dispatchLoaded(id)
         } else if (!retry(gen, id, "registerView returned false")) {
             dispatchFailed(id, "registerView returned false")
+        }
+    }
+
+    private fun runMeasureAndLayoutNow() {
+        val w = measuredWidth
+        val h = measuredHeight
+        if (w <= 0 || h <= 0) return
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+            child.visibility = VISIBLE
+            child.measure(
+                MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
+            )
+            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
         }
     }
 

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -2,16 +2,23 @@ package com.appodeal.rnappodeal
 
 import android.content.Context
 import android.graphics.Color
+import android.graphics.Typeface
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.util.TypedValue
+import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
 import com.appodeal.ads.NativeAd
 import com.appodeal.ads.nativead.NativeAdView
 import com.appodeal.ads.nativead.NativeAdViewAppWall
 import com.appodeal.ads.nativead.NativeAdViewContentStream
 import com.appodeal.ads.nativead.NativeAdViewNewsFeed
+import com.appodeal.ads.nativead.NativeIconView
+import com.appodeal.ads.nativead.NativeMediaView
 import com.appodeal.ads.nativead.Position
 import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandler
 import com.appodeal.rnappodeal.constants.NativeEvents
@@ -71,6 +78,9 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         }
 
     private var adView: NativeAdView? = null
+    private var titleView: TextView? = null
+    private var descriptionView: TextView? = null
+    private var ctaView: TextView? = null
     private var boundAdId: String? = null
     private var bindRunnable: Runnable? = null
     private var bindGeneration: Int = 0
@@ -95,7 +105,7 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     init {
         liveViews.add(WeakReference(this))
         visibility = VISIBLE
-        setBackgroundColor(Color.WHITE)
+        setBackgroundColor(Color.TRANSPARENT)
         contentDescription = "appodeal-native-host"
         clipChildren = false
         clipToPadding = false
@@ -153,6 +163,9 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             (view.parent as? ViewGroup)?.removeView(view)
         }
         removeAllViews()
+        titleView = null
+        descriptionView = null
+        ctaView = null
     }
 
     private fun ensureAdView(): NativeAdView {
@@ -192,8 +205,161 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         return when (template) {
             "newsFeed" -> NativeAdViewNewsFeed(context)
             "appWall" -> NativeAdViewAppWall(context)
+            "gridCard" -> createGridCard(context)
             else -> NativeAdViewContentStream(context)
         }
+    }
+
+    /**
+     * Portrait feed card matching our AdMob native layout:
+     * media ~56% top, then icon + title/body, then CTA.
+     * Stock contentStream is horizontal and looks broken in a tall grid cell.
+     */
+    private fun createGridCard(ctx: Context): NativeAdView {
+        val adView = NativeAdView(ctx)
+        adView.setBackgroundColor(COLOR_SURFACE)
+
+        val root = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        }
+
+        val mediaWrap = FrameLayout(ctx).apply {
+            setBackgroundColor(COLOR_MEDIA_BG)
+        }
+        val media = NativeMediaView(ctx)
+        mediaWrap.addView(
+            media,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+        val badge = TextView(ctx).apply {
+            text = "Ad"
+            setTextColor(Color.WHITE)
+            setBackgroundColor(0x8C000000.toInt())
+            setPadding(dp(ctx, 8), dp(ctx, 4), dp(ctx, 8), dp(ctx, 4))
+            textSize = 9f
+            typeface = Typeface.DEFAULT_BOLD
+            isAllCaps = true
+        }
+        mediaWrap.addView(
+            badge,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply {
+                gravity = Gravity.START or Gravity.TOP
+                setMargins(dp(ctx, 8), dp(ctx, 8), 0, 0)
+            }
+        )
+        root.addView(
+            mediaWrap,
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 0.56f)
+        )
+
+        val panel = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(COLOR_SURFACE)
+            setPadding(dp(ctx, 10), dp(ctx, 10), dp(ctx, 10), dp(ctx, 10))
+        }
+
+        val header = LinearLayout(ctx).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.TOP
+        }
+        val icon = NativeIconView(ctx)
+        header.addView(
+            icon,
+            LinearLayout.LayoutParams(dp(ctx, 34), dp(ctx, 34)).apply {
+                rightMargin = dp(ctx, 8)
+            }
+        )
+
+        val textCol = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+        val title = TextView(ctx).apply {
+            setTextColor(COLOR_TEXT)
+            textSize = 13f
+            typeface = Typeface.DEFAULT_BOLD
+            maxLines = 2
+            setLineSpacing(0f, 1.15f)
+        }
+        titleView = title
+        val description = TextView(ctx).apply {
+            setTextColor(COLOR_TEXT_SECONDARY)
+            textSize = 11f
+            maxLines = 1
+        }
+        descriptionView = description
+        textCol.addView(
+            title,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
+        textCol.addView(
+            description,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = dp(ctx, 2) }
+        )
+        header.addView(
+            textCol,
+            LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        )
+        panel.addView(
+            header,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
+
+        val cta = TextView(ctx).apply {
+            setTextColor(Color.WHITE)
+            setBackgroundColor(COLOR_CTA)
+            gravity = Gravity.CENTER
+            textSize = 12f
+            typeface = Typeface.DEFAULT_BOLD
+            setPadding(dp(ctx, 12), dp(ctx, 9), dp(ctx, 12), dp(ctx, 9))
+            maxLines = 1
+        }
+        ctaView = cta
+        panel.addView(
+            cta,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = dp(ctx, 8) }
+        )
+
+        root.addView(
+            panel,
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 0.44f)
+        )
+
+        adView.addView(
+            root,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+        adView.setMediaView(media)
+        adView.setIconView(icon)
+        adView.setTitleView(title)
+        adView.setDescriptionView(description)
+        adView.setCallToActionView(cta)
+        adView.setAdAttributionView(badge)
+        return adView
     }
 
     private fun scheduleBind(delayMs: Long) {
@@ -256,6 +422,10 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
 
         // Size the child BEFORE registerView so viewability can pass.
         val view = ensureAdView()
+        // Custom gridCard needs text filled before registerView (stock templates self-fill).
+        titleView?.text = ad.title.orEmpty().ifEmpty { "Ad" }
+        descriptionView?.text = ad.description.orEmpty()
+        ctaView?.text = ad.callToAction.orEmpty().ifEmpty { "Learn more" }
         view.visibility = VISIBLE
         runMeasureAndLayoutNow()
 
@@ -429,5 +599,19 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         private fun prune() {
             liveViews.removeAll { it.get() == null }
         }
+
+        // Match light AdMob card tokens (RN outerClip still applies theme surface/radius).
+        private val COLOR_SURFACE: Int = Color.WHITE
+        private val COLOR_MEDIA_BG: Int = Color.parseColor("#1A1515")
+        private val COLOR_TEXT: Int = Color.parseColor("#2D2424")
+        private val COLOR_TEXT_SECONDARY: Int = Color.parseColor("#7F6D5F")
+        private val COLOR_CTA: Int = Color.parseColor("#2D2424")
     }
 }
+
+private fun dp(ctx: Context, value: Int): Int =
+    TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        value.toFloat(),
+        ctx.resources.displayMetrics
+    ).toInt()

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -33,7 +33,7 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             bindAd()
         }
 
-    var template: String = "contentStream"
+    var adTemplate: String = "contentStream"
         set(value) {
             if (field != value) {
                 field = value
@@ -69,7 +69,7 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
     }
 
     private fun createNativeAdView(): NativeAdView {
-        return when (template) {
+        return when (adTemplate) {
             "newsFeed" -> NativeAdViewNewsFeed(context)
             "appWall" -> NativeAdViewAppWall(context)
             else -> NativeAdViewContentStream(context)

--- a/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RCTAppodealNativeView.kt
@@ -2,21 +2,13 @@ package com.appodeal.rnappodeal
 
 import android.content.Context
 import android.graphics.Color
-import android.graphics.Typeface
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import android.util.TypedValue
-import android.view.Gravity
 import android.view.ViewGroup
-import android.widget.Button
-import android.widget.FrameLayout
-import android.widget.LinearLayout
-import android.widget.TextView
 import com.appodeal.ads.NativeAd
-import com.appodeal.ads.nativead.NativeAdView
-import com.appodeal.ads.nativead.NativeIconView
-import com.appodeal.ads.nativead.NativeMediaView
+import com.appodeal.ads.nativead.NativeAdViewContentStream
+import com.appodeal.ads.nativead.Position
 import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandler
 import com.appodeal.rnappodeal.constants.NativeEvents
 import com.facebook.react.bridge.Arguments
@@ -24,22 +16,24 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.EventDispatcher
-import com.facebook.react.views.view.ReactViewGroup
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
-import kotlin.math.roundToInt
 
 /**
- * Hosts an Appodeal native ad using a **custom** [NativeAdView] layout.
+ * React Native host for Appodeal native ads.
  *
- * Stock templates (ContentStream/etc.) register successfully inside RN but stay
- * blank / "not visible globally" because ReactViewGroup + template GONE/VISIBLE
- * + recreate races destroy the view right after bind. Custom asset binding
- * (title/CTA/media) matches Appodeal's documented custom-layout path and paints
- * reliably in RN.
+ * Matches the official Appodeal Android demo
+ * (`appodeal/appodeal-android-sdk` → `NativeListAdapter` / `NativeActivity`):
+ * the list item **is** a [NativeAdViewContentStream], then `registerView(nativeAd)`.
+ *
+ * Previous approach nested a GONE-by-default [com.appodeal.ads.nativead.NativeAdView]
+ * inside [com.facebook.react.views.view.ReactViewGroup]. `registerView` returned true
+ * but the child stayed absent from the UI hierarchy (uiautomator: empty host), while
+ * banners (VISIBLE [com.appodeal.ads.BannerView] child) rendered fine.
  */
-class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppodealEventHandler {
+class RCTAppodealNativeView(
+    private val reactContext: ReactContext
+) : NativeAdViewContentStream(reactContext), RNAppodealEventHandler {
 
     private val surfaceId: Int by lazy { UIManagerHelper.getSurfaceId(reactContext) }
     private val uiHandler: Handler by lazy { Handler(Looper.getMainLooper()) }
@@ -64,61 +58,40 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             }
         }
 
-    /** Kept for API compat; custom layout ignores template style. */
+    /** Kept for API compat; ContentStream template is fixed (matches Android demo default). */
     @Suppress("UNUSED_PARAMETER")
     var adTemplate: String = "contentStream"
 
-    private var nativeAdView: NativeAdView? = null
-    private var titleView: TextView? = null
-    private var descriptionView: TextView? = null
-    private var ctaView: Button? = null
     private var boundAdId: String? = null
     private var bindRunnable: Runnable? = null
     private var bindGeneration: Int = 0
     private var bindAttempts: Int = 0
 
-    private val measureAndLayout = Runnable {
-        val w = measuredWidth
-        val h = measuredHeight
-        if (w <= 0 || h <= 0) return@Runnable
-        for (i in 0 until childCount) {
-            val child = getChildAt(i)
-            child.measure(
-                MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
-            )
-            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
-        }
-    }
-
     init {
         liveViews.add(WeakReference(this))
-        ensureNativeAdView()
-    }
-
-    override fun requestLayout() {
-        super.requestLayout()
-        post(measureAndLayout)
-    }
-
-    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-        super.onLayout(changed, left, top, right, bottom)
-        post(measureAndLayout)
-        if (right - left > 0 && bottom - top > 0 && boundAdId == null && !adId.isNullOrEmpty()) {
-            scheduleBind(0)
-        }
+        // Demo XML starts templates as gone; RN must keep a real laid-out host so
+        // Appodeal's viewability check can pass. Force visible like BannerView hosts.
+        visibility = VISIBLE
+        descendantFocusability = FOCUS_BLOCK_DESCENDANTS
+        setBackgroundColor(Color.WHITE)
+        setAdChoicesPosition(Position.END_TOP)
+        contentDescription = "appodeal-native-ad"
     }
 
     fun cleanup() {
         bindRunnable?.let { uiHandler.removeCallbacks(it) }
         bindRunnable = null
         bindGeneration++
-        unbindQuietly()
-        removeAllViews()
-        nativeAdView = null
-        titleView = null
-        descriptionView = null
-        ctaView = null
+        try {
+            unregisterView()
+        } catch (_: Exception) {
+        }
+        try {
+            destroy()
+        } catch (_: Exception) {
+        }
+        boundAdId = null
+        bindAttempts = 0
         val self = this
         liveViews.removeAll { it.get() == null || it.get() === self }
     }
@@ -129,137 +102,18 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         }
     }
 
-    private fun hostActivityContext(): Context {
-        return RNAppodealActivityHolder.get()
-            ?: reactContext.currentActivity
-            ?: context
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        if (right - left > 0 && bottom - top > 0 && boundAdId == null && !adId.isNullOrEmpty()) {
+            scheduleBind(0)
+        }
     }
 
-    private fun ensureNativeAdView() {
-        if (nativeAdView != null) return
-        val view = buildCustomNativeAdView(hostActivityContext())
-        nativeAdView = view
-        addView(
-            view,
-            LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-        )
-        post(measureAndLayout)
-    }
-
-    private fun buildCustomNativeAdView(ctx: Context): NativeAdView {
-        val adView = NativeAdView(ctx)
-        adView.setBackgroundColor(Color.WHITE)
-
-        val root = LinearLayout(ctx).apply {
-            orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Color.WHITE)
-            setPadding(dpPx(ctx, 8), dpPx(ctx, 8), dpPx(ctx, 8), dpPx(ctx, 8))
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (boundAdId == null && !adId.isNullOrEmpty()) {
+            scheduleBind(0)
         }
-
-        val attribution = TextView(ctx).apply {
-            text = "Ad"
-            setTextColor(Color.WHITE)
-            setBackgroundColor(Color.parseColor("#FF9800"))
-            setPadding(dpPx(ctx, 6), dpPx(ctx, 2), dpPx(ctx, 6), dpPx(ctx, 2))
-            textSize = 10f
-            typeface = Typeface.DEFAULT_BOLD
-        }
-
-        val header = LinearLayout(ctx).apply {
-            orientation = LinearLayout.HORIZONTAL
-            gravity = Gravity.CENTER_VERTICAL
-        }
-
-        val icon = NativeIconView(ctx)
-        val iconLp = LinearLayout.LayoutParams(dpPx(ctx, 40), dpPx(ctx, 40)).apply {
-            rightMargin = dpPx(ctx, 8)
-        }
-
-        val title = TextView(ctx).apply {
-            setTextColor(Color.BLACK)
-            textSize = 14f
-            typeface = Typeface.DEFAULT_BOLD
-            maxLines = 2
-        }
-        titleView = title
-
-        header.addView(icon, iconLp)
-        header.addView(
-            title,
-            LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
-        )
-
-        val description = TextView(ctx).apply {
-            setTextColor(Color.DKGRAY)
-            textSize = 12f
-            maxLines = 3
-        }
-        descriptionView = description
-
-        val media = NativeMediaView(ctx).apply {
-            setBackgroundColor(Color.parseColor("#EEEEEE"))
-        }
-
-        val cta = Button(ctx).apply {
-            isAllCaps = false
-            setTextColor(Color.WHITE)
-            setBackgroundColor(Color.parseColor("#1A73E8"))
-        }
-        ctaView = cta
-
-        root.addView(
-            attribution,
-            LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            )
-        )
-        root.addView(
-            header,
-            LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            ).apply { topMargin = dpPx(ctx, 6) }
-        )
-        root.addView(
-            description,
-            LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            ).apply { topMargin = dpPx(ctx, 4) }
-        )
-        root.addView(
-            media,
-            LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                0,
-                1f
-            ).apply { topMargin = dpPx(ctx, 6) }
-        )
-        root.addView(
-            cta,
-            LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            ).apply { topMargin = dpPx(ctx, 6) }
-        )
-
-        adView.addView(
-            root,
-            FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-        )
-
-        adView.setTitleView(title)
-        adView.setDescriptionView(description)
-        adView.setCallToActionView(cta)
-        adView.setIconView(icon)
-        adView.setMediaView(media)
-        adView.setAdAttributionView(attribution)
-
-        return adView
     }
 
     private fun scheduleBind(delayMs: Long) {
@@ -285,9 +139,16 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             return
         }
 
-        if (measuredWidth <= 0 || measuredHeight <= 0) {
+        if (width <= 0 || height <= 0) {
             if (!retry(gen, id, "view has zero size")) {
                 dispatchFailed(id, "view has zero size")
+            }
+            return
+        }
+
+        if (!isAttachedToWindow) {
+            if (!retry(gen, id, "not attached to window")) {
+                dispatchFailed(id, "not attached to window")
             }
             return
         }
@@ -299,19 +160,6 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             }
             return
         }
-
-        ensureNativeAdView()
-        val view = nativeAdView ?: run {
-            dispatchFailed(id, "native ad view missing")
-            return
-        }
-
-        // Populate assets BEFORE registerView (Appodeal custom-layout contract).
-        titleView?.text = ad.title.orEmpty().ifEmpty { "Ad" }
-        descriptionView?.text = ad.description.orEmpty()
-        ctaView?.text = ad.callToAction.orEmpty().ifEmpty { "Learn more" }
-
-        post(measureAndLayout)
 
         val canShow = try {
             ad.canShow(activity, placement)
@@ -326,22 +174,33 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
             return
         }
 
-        // Do NOT destroy/recreate here — that was wiping a successful register.
+        // Same sequence as NativeActivity.showNative / NativeListAdapter.bind:
+        // configure → registerView(nativeAd). Do not destroy/recreate between binds.
         try {
-            view.unregisterView()
+            unregisterView()
         } catch (_: Exception) {
         }
 
+        visibility = VISIBLE
+
         val registered = try {
-            view.registerView(ad, placement)
+            registerView(ad, placement)
         } catch (e: Exception) {
             Log.e(TAG, "registerView threw", e)
             false
         }
 
+        // SDK flips GONE→VISIBLE on success; keep forcing VISIBLE for RN hosts.
+        visibility = VISIBLE
+        bringToFront()
+        (parent as? ViewGroup)?.bringChildToFront(this)
+        requestLayout()
+        invalidate()
+
         Log.d(
             TAG,
-            "registerView id=$id result=$registered size=${measuredWidth}x${measuredHeight} title=${ad.title}"
+            "registerView id=$id result=$registered size=${width}x${height} " +
+                "vis=$visibility attached=$isAttachedToWindow title=${ad.title}"
         )
 
         if (gen != bindGeneration) return
@@ -349,12 +208,14 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         if (registered) {
             boundAdId = id
             bindAttempts = 0
-            visibility = VISIBLE
-            view.visibility = VISIBLE
-            post(measureAndLayout)
-            // Second layout pass after SDK mutates media children.
             uiHandler.postDelayed({
-                if (gen == bindGeneration) post(measureAndLayout)
+                if (gen != bindGeneration) return@postDelayed
+                visibility = VISIBLE
+                requestLayout()
+                Log.d(
+                    TAG,
+                    "post-bind childCount=$childCount size=${width}x${height} vis=$visibility"
+                )
             }, 100L)
             dispatchLoaded(id)
         } else if (!retry(gen, id, "registerView returned false")) {
@@ -371,51 +232,38 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         return true
     }
 
-    private fun unbindQuietly() {
-        try {
-            nativeAdView?.unregisterView()
-        } catch (_: Exception) {
-        }
-        try {
-            nativeAdView?.destroy()
-        } catch (_: Exception) {
-        }
-        boundAdId = null
-        bindAttempts = 0
+    private fun dispatchLoaded(adIdValue: String) {
+        val params = Arguments.createMap().apply { putString("adId", adIdValue) }
+        dispatchFabricEvent(id, NativeEvents.ON_AD_LOADED, params)
     }
 
-    private fun dispatchLoaded(id: String) {
-        val params = Arguments.createMap().apply { putString("adId", id) }
-        dispatchFabricEvent(getId(), NativeEvents.ON_AD_LOADED, params)
-    }
-
-    private fun dispatchFailed(id: String, message: String) {
-        Log.w(TAG, "bind failed id=$id message=$message")
+    private fun dispatchFailed(adIdValue: String, message: String) {
+        Log.w(TAG, "bind failed id=$adIdValue message=$message")
         val params = Arguments.createMap().apply {
-            putString("adId", id)
+            putString("adId", adIdValue)
             putString("message", message)
         }
-        dispatchFabricEvent(getId(), NativeEvents.ON_AD_FAILED_TO_LOAD, params)
+        dispatchFabricEvent(id, NativeEvents.ON_AD_FAILED_TO_LOAD, params)
     }
 
     override fun handleEvent(event: String, params: WritableMap?) {
         when (event) {
             NativeEvents.ON_NATIVE_SHOWN -> {
                 if (boundAdId == null) return
-                dispatchFabricEvent(getId(), NativeEvents.ON_AD_SHOWN, withAdId(params))
+                dispatchFabricEvent(id, NativeEvents.ON_AD_SHOWN, withAdId(params))
             }
             NativeEvents.ON_NATIVE_CLICKED -> {
                 if (boundAdId == null) return
-                dispatchFabricEvent(getId(), NativeEvents.ON_AD_CLICKED, withAdId(params))
+                dispatchFabricEvent(id, NativeEvents.ON_AD_CLICKED, withAdId(params))
             }
             NativeEvents.ON_NATIVE_EXPIRED -> {
                 if (boundAdId == null) return
                 try {
-                    nativeAdView?.unregisterView()
+                    unregisterView()
                 } catch (_: Exception) {
                 }
                 boundAdId = null
-                dispatchFabricEvent(getId(), NativeEvents.ON_AD_EXPIRED, withAdId(params))
+                dispatchFabricEvent(id, NativeEvents.ON_AD_EXPIRED, withAdId(params))
             }
             else -> Unit
         }
@@ -449,9 +297,6 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         }
     }
 
-    private val reactContext: ReactContext
-        get() = context as ReactContext
-
     companion object {
         private const val TAG = "RNAppodealNative"
         private const val MAX_BIND_ATTEMPTS = 6
@@ -471,7 +316,7 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
                 if (view.adId == adId || view.boundAdId == adId) {
                     view.bindGeneration++
                     try {
-                        view.nativeAdView?.unregisterView()
+                        view.unregisterView()
                     } catch (_: Exception) {
                     }
                     view.boundAdId = null
@@ -484,10 +329,3 @@ class RCTAppodealNativeView(context: Context) : ReactViewGroup(context), RNAppod
         }
     }
 }
-
-private fun dpPx(ctx: Context, value: Int): Int =
-    TypedValue.applyDimension(
-        TypedValue.COMPLEX_UNIT_DIP,
-        value.toFloat(),
-        ctx.resources.displayMetrics
-    ).roundToInt()

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealActivityHolder.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealActivityHolder.kt
@@ -1,0 +1,19 @@
+package com.appodeal.rnappodeal
+
+import android.app.Activity
+import java.lang.ref.WeakReference
+
+/**
+ * Shared Activity ref for native ad views.
+ * Mirrors [RNAppodealModuleImpl]'s workaround for RN's null getCurrentActivity bug.
+ */
+internal object RNAppodealActivityHolder {
+    @Volatile
+    private var activityRef: WeakReference<Activity>? = null
+
+    fun set(activity: Activity?) {
+        activityRef = if (activity != null) WeakReference(activity) else null
+    }
+
+    fun get(): Activity? = activityRef?.get()
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealModuleImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealModuleImpl.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.util.Log
 import com.appodeal.ads.Appodeal
+import com.appodeal.ads.NativeMediaViewContentType
 import com.appodeal.ads.inapp.InAppPurchase
 import com.appodeal.ads.inapp.InAppPurchaseValidateCallback
 import com.appodeal.ads.service.ServiceError
@@ -11,6 +12,7 @@ import com.appodeal.rnappodeal.callbacks.RNAppodealAdRevenueCallbacks
 import com.appodeal.rnappodeal.callbacks.RNAppodealBannerCallbacks
 import com.appodeal.rnappodeal.callbacks.RNAppodealInterstitialCallbacks
 import com.appodeal.rnappodeal.callbacks.RNAppodealMrecCallbacks
+import com.appodeal.rnappodeal.callbacks.RNAppodealNativeCallbacks
 import com.appodeal.rnappodeal.callbacks.RNAppodealRewardedVideoCallbacks
 import com.appodeal.rnappodeal.ext.AdTypeExtensions.toAppodealTypes
 import com.appodeal.rnappodeal.ext.LogLevelExtensions.toLogLevel
@@ -27,6 +29,7 @@ import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import java.lang.ref.WeakReference
 
@@ -42,6 +45,7 @@ internal class RNAppodealModuleImpl(
     private val mrecCallbacks by lazy { RNAppodealMrecCallbacks(eventDispatcher) }
     private val rewardedVideoCallbacks by lazy { RNAppodealRewardedVideoCallbacks(eventDispatcher) }
     private val adRevenueCallbacks by lazy { RNAppodealAdRevenueCallbacks(eventDispatcher) }
+    private val nativeCallbacks by lazy { RNAppodealNativeCallbacks(eventDispatcher) }
 
     // Consent handler
     private val consentHandler by lazy { RNAppodealConsent() }
@@ -114,6 +118,7 @@ internal class RNAppodealModuleImpl(
         Appodeal.setBannerCallbacks(bannerCallbacks)
         Appodeal.setMrecCallbacks(mrecCallbacks)
         Appodeal.setRewardedVideoCallbacks(rewardedVideoCallbacks)
+        Appodeal.setNativeCallbacks(nativeCallbacks)
         Appodeal.setAdRevenueCallbacks(adRevenueCallbacks)
 
         // Set up Appodeal options
@@ -386,6 +391,37 @@ internal class RNAppodealModuleImpl(
 
     fun trackEvent(name: String, parameters: ReadableMap) {
         Appodeal.logEvent(name, parameters.toMap())
+    }
+
+    fun getNativeAds(count: Double): WritableArray {
+        val ads = Appodeal.getNativeAds(count.toInt())
+        val storedAds = RNAppodealNativeAdStore.putAds(ads)
+        return Arguments.createArray().apply {
+            storedAds.forEach { pushMap(it) }
+        }
+    }
+
+    fun getAvailableNativeAdsCount(): Double {
+        return Appodeal.getAvailableNativeAdsCount().toDouble()
+    }
+
+    fun destroyNativeAd(adId: String) {
+        RNAppodealNativeAdStore.remove(adId)
+    }
+
+    fun cacheNativeAds(count: Double) {
+        withActivity("cacheNativeAds") { activity ->
+            Appodeal.cache(activity, Appodeal.NATIVE, count.toInt().coerceIn(1, 5))
+        }
+    }
+
+    fun setPreferredNativeContentType(type: String) {
+        val contentType = when (type) {
+            "noVideo" -> NativeMediaViewContentType.NoVideo
+            "video" -> NativeMediaViewContentType.Video
+            else -> NativeMediaViewContentType.Auto
+        }
+        Appodeal.setPreferredNativeContentType(contentType)
     }
 
     // MARK: - Event Management

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealModuleImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealModuleImpl.kt
@@ -55,6 +55,7 @@ internal class RNAppodealModuleImpl(
 
     init {
         this.currentActivity = WeakReference(reactContext.currentActivity)
+        RNAppodealActivityHolder.set(reactContext.currentActivity)
         this.reactContext.addLifecycleEventListener(this)
     }
 
@@ -66,8 +67,9 @@ internal class RNAppodealModuleImpl(
     private fun getActivity(): Activity? {
         if (reactContext.hasCurrentActivity()) {
             currentActivity = WeakReference(reactContext.currentActivity)
+            RNAppodealActivityHolder.set(reactContext.currentActivity)
         }
-        return currentActivity?.get()
+        return currentActivity?.get() ?: RNAppodealActivityHolder.get()
     }
 
     /**
@@ -412,6 +414,7 @@ internal class RNAppodealModuleImpl(
     }
 
     fun destroyNativeAd(adId: String) {
+        RCTAppodealNativeView.unbindAdId(adId)
         RNAppodealNativeAdStore.remove(adId)
     }
 
@@ -460,7 +463,12 @@ internal class RNAppodealModuleImpl(
     }
 
     override fun onHostResume() {
-        // Not implemented
+        val activity = reactContext.currentActivity
+        if (activity != null) {
+            currentActivity = WeakReference(activity)
+            RNAppodealActivityHolder.set(activity)
+        }
+        RCTAppodealNativeView.notifyActivityReady()
     }
 
     companion object Companion {

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealModuleImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealModuleImpl.kt
@@ -415,6 +415,7 @@ internal class RNAppodealModuleImpl(
 
     fun destroyNativeAd(adId: String) {
         RCTAppodealNativeView.unbindAdId(adId)
+        RCTAppodealNativeAdView.unbindAdId(adId)
         RNAppodealNativeAdStore.remove(adId)
     }
 
@@ -469,6 +470,7 @@ internal class RNAppodealModuleImpl(
             RNAppodealActivityHolder.set(activity)
         }
         RCTAppodealNativeView.notifyActivityReady()
+        RCTAppodealNativeAdView.notifyActivityReady()
     }
 
     companion object Companion {

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealModuleImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealModuleImpl.kt
@@ -29,7 +29,6 @@ import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import java.lang.ref.WeakReference
 
@@ -393,11 +392,18 @@ internal class RNAppodealModuleImpl(
         Appodeal.logEvent(name, parameters.toMap())
     }
 
-    fun getNativeAds(count: Double): WritableArray {
+    /**
+     * TurboModule codegen maps Spec `UnsafeObject` → WritableMap.
+     * Shape: `{ ads: Array<NativeAdInfo> }`.
+     */
+    fun getNativeAds(count: Double): WritableMap {
         val ads = Appodeal.getNativeAds(count.toInt())
         val storedAds = RNAppodealNativeAdStore.putAds(ads)
-        return Arguments.createArray().apply {
+        val array = Arguments.createArray().apply {
             storedAds.forEach { pushMap(it) }
+        }
+        return Arguments.createMap().apply {
+            putArray("ads", array)
         }
     }
 

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealNativeAdStore.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealNativeAdStore.kt
@@ -1,0 +1,38 @@
+package com.appodeal.rnappodeal
+
+import com.appodeal.ads.NativeAd
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+internal object RNAppodealNativeAdStore {
+
+    private val ads = ConcurrentHashMap<String, NativeAd>()
+
+    fun putAds(ads: List<NativeAd>): List<WritableMap> {
+        return ads.map { ad ->
+            val id = UUID.randomUUID().toString()
+            this.ads[id] = ad
+            ad.toWritableMap(id)
+        }
+    }
+
+    fun get(id: String): NativeAd? = ads[id]
+
+    fun remove(id: String) {
+        ads.remove(id)
+    }
+
+    private fun NativeAd.toWritableMap(id: String): WritableMap {
+        return Arguments.createMap().apply {
+            putString("id", id)
+            putString("title", title.orEmpty())
+            putString("description", description.orEmpty())
+            putString("callToAction", callToAction.orEmpty())
+            putDouble("rating", rating.toDouble())
+            putBoolean("containsVideo", containsVideo())
+            putDouble("predictedEcpm", predictedEcpm)
+        }
+    }
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealNativeAdViewManagerImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealNativeAdViewManagerImpl.kt
@@ -1,0 +1,34 @@
+package com.appodeal.rnappodeal
+
+import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandlerManager
+import com.appodeal.rnappodeal.constants.NativeEvents
+import com.facebook.react.uimanager.ThemedReactContext
+
+internal class RNAppodealNativeAdViewManagerImpl(
+    private val handlerManager: RNAppodealEventHandlerManager = RNAppodealEventHandlerManager
+) {
+    fun createViewInstance(reactContext: ThemedReactContext): RCTAppodealNativeAdView {
+        val view = RCTAppodealNativeAdView(reactContext)
+        handlerManager.registerHandler(view)
+        return view
+    }
+
+    fun onDropViewInstance(view: RCTAppodealNativeAdView) {
+        view.cleanup()
+        handlerManager.unregisterHandler(view)
+    }
+
+    fun getExportedCustomDirectEventTypeConstants(): Map<String?, Any?>? {
+        return mapOf(
+            NativeEvents.ON_AD_LOADED to mapOf("registrationName" to NativeEvents.ON_AD_LOADED),
+            NativeEvents.ON_AD_FAILED_TO_LOAD to mapOf("registrationName" to NativeEvents.ON_AD_FAILED_TO_LOAD),
+            NativeEvents.ON_AD_SHOWN to mapOf("registrationName" to NativeEvents.ON_AD_SHOWN),
+            NativeEvents.ON_AD_CLICKED to mapOf("registrationName" to NativeEvents.ON_AD_CLICKED),
+            NativeEvents.ON_AD_EXPIRED to mapOf("registrationName" to NativeEvents.ON_AD_EXPIRED)
+        )
+    }
+
+    companion object {
+        const val NAME = "RNAppodealNativeAdView"
+    }
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealNativeAssetViewManagerImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealNativeAssetViewManagerImpl.kt
@@ -1,0 +1,17 @@
+package com.appodeal.rnappodeal
+
+import com.facebook.react.uimanager.ThemedReactContext
+
+internal class RNAppodealNativeAssetViewManagerImpl {
+    fun createViewInstance(reactContext: ThemedReactContext): RCTAppodealNativeAssetView {
+        return RCTAppodealNativeAssetView(reactContext)
+    }
+
+    fun onDropViewInstance(view: RCTAppodealNativeAssetView) {
+        // no-op
+    }
+
+    companion object {
+        const val NAME = RCTAppodealNativeAssetView.NAME
+    }
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealNativeViewManagerImpl.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealNativeViewManagerImpl.kt
@@ -1,0 +1,35 @@
+package com.appodeal.rnappodeal
+
+import com.appodeal.rnappodeal.callbacks.RNAppodealEventHandlerManager
+import com.appodeal.rnappodeal.constants.NativeEvents
+import com.facebook.react.uimanager.ThemedReactContext
+
+internal class RNAppodealNativeViewManagerImpl(
+    private val handlerManager: RNAppodealEventHandlerManager = RNAppodealEventHandlerManager
+) {
+
+    fun createViewInstance(reactContext: ThemedReactContext): RCTAppodealNativeView {
+        val nativeView = RCTAppodealNativeView(reactContext)
+        handlerManager.registerHandler(nativeView)
+        return nativeView
+    }
+
+    fun onDropViewInstance(view: RCTAppodealNativeView) {
+        view.cleanup()
+        handlerManager.unregisterHandler(view)
+    }
+
+    fun getExportedCustomDirectEventTypeConstants(): Map<String?, Any?>? {
+        return mapOf(
+            NativeEvents.ON_AD_LOADED to mapOf("registrationName" to NativeEvents.ON_AD_LOADED),
+            NativeEvents.ON_AD_FAILED_TO_LOAD to mapOf("registrationName" to NativeEvents.ON_AD_FAILED_TO_LOAD),
+            NativeEvents.ON_AD_SHOWN to mapOf("registrationName" to NativeEvents.ON_AD_SHOWN),
+            NativeEvents.ON_AD_CLICKED to mapOf("registrationName" to NativeEvents.ON_AD_CLICKED),
+            NativeEvents.ON_AD_EXPIRED to mapOf("registrationName" to NativeEvents.ON_AD_EXPIRED)
+        )
+    }
+
+    companion object Companion {
+        const val NAME = "RNAppodealNativeView"
+    }
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealPackage.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealPackage.kt
@@ -21,7 +21,9 @@ class RNAppodealPackage : BaseReactPackage() {
     ): List<ViewManager<*, *>> = listOf(
         RNAppodealBannerViewManager(),
         RNAppodealMrecViewManager(),
-        RNAppodealNativeViewManager()
+        RNAppodealNativeViewManager(),
+        RNAppodealNativeAdViewManager(),
+        RNAppodealNativeAssetViewManager()
     )
 
     override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {

--- a/android/src/main/java/com/appodeal/rnappodeal/RNAppodealPackage.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/RNAppodealPackage.kt
@@ -20,7 +20,8 @@ class RNAppodealPackage : BaseReactPackage() {
         reactContext: ReactApplicationContext
     ): List<ViewManager<*, *>> = listOf(
         RNAppodealBannerViewManager(),
-        RNAppodealMrecViewManager()
+        RNAppodealMrecViewManager(),
+        RNAppodealNativeViewManager()
     )
 
     override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {

--- a/android/src/main/java/com/appodeal/rnappodeal/callbacks/RNAppodealNativeCallbacks.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/callbacks/RNAppodealNativeCallbacks.kt
@@ -1,0 +1,67 @@
+package com.appodeal.rnappodeal.callbacks
+
+import com.appodeal.ads.NativeAd
+import com.appodeal.ads.NativeCallbacks
+import com.appodeal.rnappodeal.RNAEventDispatcher
+import com.appodeal.rnappodeal.constants.NativeEvents
+import com.facebook.react.bridge.Arguments
+
+/**
+ * Callback handler for Appodeal native ad events.
+ *
+ * This class implements the NativeCallbacks interface and handles native ad lifecycle events
+ * including loading, showing, clicking, and expiration. It forwards events to both:
+ *
+ * 1. **Event Dispatcher**: For advanced event management with priority handling
+ * 2. **Event Handler Manager**: For Fabric/New Architecture event dispatching
+ *
+ * @param eventDispatcher The RNAEventDispatcher instance used for advanced event management
+ * @param handlers The event handler manager that forwards events to registered native views
+ */
+internal class RNAppodealNativeCallbacks(
+    private val eventDispatcher: RNAEventDispatcher,
+    private val handlers: RNAppodealEventHandler = RNAppodealEventHandlerManager
+) : NativeCallbacks {
+
+    override fun onNativeLoaded() {
+        eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_LOADED, null)
+        handlers.handleEvent(NativeEvents.ON_NATIVE_LOADED, null)
+    }
+
+    override fun onNativeFailedToLoad() {
+        eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_FAILED_TO_LOAD, null)
+        handlers.handleEvent(NativeEvents.ON_NATIVE_FAILED_TO_LOAD, null)
+    }
+
+    override fun onNativeShown(nativeAd: NativeAd) {
+        val params = createNativeAdParams(nativeAd)
+        eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_SHOWN, params)
+        handlers.handleEvent(NativeEvents.ON_NATIVE_SHOWN, params)
+    }
+
+    override fun onNativeShowFailed(nativeAd: NativeAd) {
+        val params = createNativeAdParams(nativeAd)
+        eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_SHOW_FAILED, params)
+        handlers.handleEvent(NativeEvents.ON_NATIVE_SHOW_FAILED, params)
+    }
+
+    override fun onNativeClicked(nativeAd: NativeAd) {
+        val params = createNativeAdParams(nativeAd)
+        eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_CLICKED, params)
+        handlers.handleEvent(NativeEvents.ON_NATIVE_CLICKED, params)
+    }
+
+    override fun onNativeExpired() {
+        eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_EXPIRED, null)
+        handlers.handleEvent(NativeEvents.ON_NATIVE_EXPIRED, null)
+    }
+
+    private fun createNativeAdParams(nativeAd: NativeAd) = Arguments.createMap().apply {
+        putString("title", nativeAd.title ?: "")
+        putString("description", nativeAd.description ?: "")
+        putString("callToAction", nativeAd.callToAction ?: "")
+        putDouble("rating", nativeAd.rating.toDouble())
+        putBoolean("containsVideo", nativeAd.containsVideo())
+        putDouble("predictedEcpm", nativeAd.predictedEcpm)
+    }
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/callbacks/RNAppodealNativeCallbacks.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/callbacks/RNAppodealNativeCallbacks.kt
@@ -9,14 +9,8 @@ import com.facebook.react.bridge.Arguments
 /**
  * Callback handler for Appodeal native ad events.
  *
- * This class implements the NativeCallbacks interface and handles native ad lifecycle events
- * including loading, showing, clicking, and expiration. It forwards events to both:
- *
- * 1. **Event Dispatcher**: For advanced event management with priority handling
- * 2. **Event Handler Manager**: For Fabric/New Architecture event dispatching
- *
- * @param eventDispatcher The RNAEventDispatcher instance used for advanced event management
- * @param handlers The event handler manager that forwards events to registered native views
+ * Appodeal 4.2.0 exposes these Java callbacks as platform types; Kotlin sees
+ * the NativeAd parameters as nullable (`NativeAd?`).
  */
 internal class RNAppodealNativeCallbacks(
     private val eventDispatcher: RNAEventDispatcher,
@@ -33,19 +27,19 @@ internal class RNAppodealNativeCallbacks(
         handlers.handleEvent(NativeEvents.ON_NATIVE_FAILED_TO_LOAD, null)
     }
 
-    override fun onNativeShown(nativeAd: NativeAd) {
+    override fun onNativeShown(nativeAd: NativeAd?) {
         val params = createNativeAdParams(nativeAd)
         eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_SHOWN, params)
         handlers.handleEvent(NativeEvents.ON_NATIVE_SHOWN, params)
     }
 
-    override fun onNativeShowFailed(nativeAd: NativeAd) {
+    override fun onNativeShowFailed(nativeAd: NativeAd?) {
         val params = createNativeAdParams(nativeAd)
         eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_SHOW_FAILED, params)
         handlers.handleEvent(NativeEvents.ON_NATIVE_SHOW_FAILED, params)
     }
 
-    override fun onNativeClicked(nativeAd: NativeAd) {
+    override fun onNativeClicked(nativeAd: NativeAd?) {
         val params = createNativeAdParams(nativeAd)
         eventDispatcher.dispatchEvent(NativeEvents.ON_NATIVE_CLICKED, params)
         handlers.handleEvent(NativeEvents.ON_NATIVE_CLICKED, params)
@@ -56,7 +50,8 @@ internal class RNAppodealNativeCallbacks(
         handlers.handleEvent(NativeEvents.ON_NATIVE_EXPIRED, null)
     }
 
-    private fun createNativeAdParams(nativeAd: NativeAd) = Arguments.createMap().apply {
+    private fun createNativeAdParams(nativeAd: NativeAd?) = Arguments.createMap().apply {
+        if (nativeAd == null) return@apply
         putString("title", nativeAd.title ?: "")
         putString("description", nativeAd.description ?: "")
         putString("callToAction", nativeAd.callToAction ?: "")

--- a/android/src/main/java/com/appodeal/rnappodeal/constants/NativeEvents.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/constants/NativeEvents.kt
@@ -1,0 +1,21 @@
+package com.appodeal.rnappodeal.constants
+
+/**
+ * Constants for native ad events.
+ * Centralized event names that can be reused across the codebase.
+ */
+internal object NativeEvents {
+    const val ON_NATIVE_LOADED = "onNativeLoaded"
+    const val ON_NATIVE_FAILED_TO_LOAD = "onNativeFailedToLoad"
+    const val ON_NATIVE_SHOWN = "onNativeShown"
+    const val ON_NATIVE_SHOW_FAILED = "onNativeShowFailed"
+    const val ON_NATIVE_CLICKED = "onNativeClicked"
+    const val ON_NATIVE_EXPIRED = "onNativeExpired"
+
+    // React Native event registration names
+    const val ON_AD_LOADED = "onAdLoaded"
+    const val ON_AD_FAILED_TO_LOAD = "onAdFailedToLoad"
+    const val ON_AD_CLICKED = "onAdClicked"
+    const val ON_AD_EXPIRED = "onAdExpired"
+    const val ON_AD_SHOWN = "onAdShown"
+}

--- a/android/src/main/java/com/appodeal/rnappodeal/ext/AdTypeExtensions.kt
+++ b/android/src/main/java/com/appodeal/rnappodeal/ext/AdTypeExtensions.kt
@@ -24,6 +24,7 @@ internal object AdTypeExtensions {
         if (types.hasFlag(BANNER_TOP_FLAG)) result = result or Appodeal.BANNER_TOP
         if (types.hasFlag(REWARDED_VIDEO_FLAG)) result = result or Appodeal.REWARDED_VIDEO
         if (types.hasFlag(MREC_FLAG)) result = result or Appodeal.MREC
+        if (types.hasFlag(NATIVE_FLAG)) result = result or Appodeal.NATIVE
 
         return result
     }
@@ -42,6 +43,7 @@ internal object AdTypeExtensions {
         if (this.hasFlag(Appodeal.BANNER_TOP)) result = result or BANNER_TOP_FLAG
         if (this.hasFlag(Appodeal.REWARDED_VIDEO)) result = result or REWARDED_VIDEO_FLAG
         if (this.hasFlag(Appodeal.MREC)) result = result or MREC_FLAG
+        if (this.hasFlag(Appodeal.NATIVE)) result = result or NATIVE_FLAG
 
         return result
     }
@@ -61,4 +63,5 @@ internal object AdTypeExtensions {
     private const val BANNER_TOP_FLAG = 1 shl 4
     private const val REWARDED_VIDEO_FLAG = 1 shl 5
     private const val MREC_FLAG = 1 shl 8
+    private const val NATIVE_FLAG = 1 shl 7
 } 

--- a/android/src/newarch/com/appodeal/rnappodeal/RNAppodealModule.kt
+++ b/android/src/newarch/com/appodeal/rnappodeal/RNAppodealModule.kt
@@ -3,7 +3,6 @@ package com.appodeal.rnappodeal
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.module.annotations.ReactModule
 
@@ -198,7 +197,7 @@ class RNAppodealModule(
         moduleImplementation.trackEvent(name, parameters)
     }
 
-    override fun getNativeAds(count: Double): WritableArray {
+    override fun getNativeAds(count: Double): WritableMap {
         return moduleImplementation.getNativeAds(count)
     }
 

--- a/android/src/newarch/com/appodeal/rnappodeal/RNAppodealModule.kt
+++ b/android/src/newarch/com/appodeal/rnappodeal/RNAppodealModule.kt
@@ -3,6 +3,7 @@ package com.appodeal.rnappodeal
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.module.annotations.ReactModule
 
@@ -195,6 +196,26 @@ class RNAppodealModule(
 
     override fun trackEvent(name: String, parameters: ReadableMap) {
         moduleImplementation.trackEvent(name, parameters)
+    }
+
+    override fun getNativeAds(count: Double): WritableArray {
+        return moduleImplementation.getNativeAds(count)
+    }
+
+    override fun getAvailableNativeAdsCount(): Double {
+        return moduleImplementation.getAvailableNativeAdsCount()
+    }
+
+    override fun destroyNativeAd(adId: String) {
+        moduleImplementation.destroyNativeAd(adId)
+    }
+
+    override fun cacheNativeAds(count: Double) {
+        moduleImplementation.cacheNativeAds(count)
+    }
+
+    override fun setPreferredNativeContentType(type: String) {
+        moduleImplementation.setPreferredNativeContentType(type)
     }
 
     override fun eventsNotifyReady(ready: Boolean) {

--- a/android/src/newarch/com/appodeal/rnappodeal/RNAppodealNativeAdViewManager.kt
+++ b/android/src/newarch/com/appodeal/rnappodeal/RNAppodealNativeAdViewManager.kt
@@ -1,0 +1,38 @@
+package com.appodeal.rnappodeal
+
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.annotations.ReactProp
+
+@ReactModule(name = RNAppodealNativeAdViewManagerImpl.NAME)
+class RNAppodealNativeAdViewManager :
+    ViewGroupManager<RCTAppodealNativeAdView>() {
+
+    private val impl = RNAppodealNativeAdViewManagerImpl()
+
+    override fun getName(): String = RNAppodealNativeAdViewManagerImpl.NAME
+
+    override fun createViewInstance(reactContext: ThemedReactContext): RCTAppodealNativeAdView {
+        return impl.createViewInstance(reactContext)
+    }
+
+    override fun onDropViewInstance(view: RCTAppodealNativeAdView) {
+        super.onDropViewInstance(view)
+        impl.onDropViewInstance(view)
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): Map<String?, Any?>? {
+        return impl.getExportedCustomDirectEventTypeConstants()
+    }
+
+    @ReactProp(name = "adId")
+    fun setAdId(view: RCTAppodealNativeAdView, value: String?) {
+        view.adId = value
+    }
+
+    @ReactProp(name = "placement")
+    fun setPlacement(view: RCTAppodealNativeAdView, value: String?) {
+        value?.let { view.placement = it }
+    }
+}

--- a/android/src/newarch/com/appodeal/rnappodeal/RNAppodealNativeAssetViewManager.kt
+++ b/android/src/newarch/com/appodeal/rnappodeal/RNAppodealNativeAssetViewManager.kt
@@ -1,0 +1,29 @@
+package com.appodeal.rnappodeal
+
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+
+@ReactModule(name = RNAppodealNativeAssetViewManagerImpl.NAME)
+class RNAppodealNativeAssetViewManager :
+    SimpleViewManager<RCTAppodealNativeAssetView>() {
+
+    private val impl = RNAppodealNativeAssetViewManagerImpl()
+
+    override fun getName(): String = RNAppodealNativeAssetViewManagerImpl.NAME
+
+    override fun createViewInstance(reactContext: ThemedReactContext): RCTAppodealNativeAssetView {
+        return impl.createViewInstance(reactContext)
+    }
+
+    override fun onDropViewInstance(view: RCTAppodealNativeAssetView) {
+        super.onDropViewInstance(view)
+        impl.onDropViewInstance(view)
+    }
+
+    @ReactProp(name = "asset")
+    fun setAsset(view: RCTAppodealNativeAssetView, value: String?) {
+        value?.let { view.assetType = it }
+    }
+}

--- a/android/src/newarch/com/appodeal/rnappodeal/RNAppodealNativeViewManager.kt
+++ b/android/src/newarch/com/appodeal/rnappodeal/RNAppodealNativeViewManager.kt
@@ -1,0 +1,43 @@
+package com.appodeal.rnappodeal
+
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+
+@ReactModule(name = RNAppodealNativeViewManagerImpl.NAME)
+class RNAppodealNativeViewManager :
+    SimpleViewManager<RCTAppodealNativeView>() {
+
+    private val nativeViewManagerImpl = RNAppodealNativeViewManagerImpl()
+
+    override fun getName(): String = RNAppodealNativeViewManagerImpl.NAME
+
+    override fun createViewInstance(reactContext: ThemedReactContext): RCTAppodealNativeView {
+        return nativeViewManagerImpl.createViewInstance(reactContext)
+    }
+
+    override fun onDropViewInstance(view: RCTAppodealNativeView) {
+        super.onDropViewInstance(view)
+        nativeViewManagerImpl.onDropViewInstance(view)
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): Map<String?, Any?>? {
+        return nativeViewManagerImpl.getExportedCustomDirectEventTypeConstants()
+    }
+
+    @ReactProp(name = "adId")
+    fun setAdId(view: RCTAppodealNativeView, value: String?) {
+        view.adId = value
+    }
+
+    @ReactProp(name = "placement")
+    fun setPlacement(view: RCTAppodealNativeView, value: String?) {
+        value?.let { view.placement = it }
+    }
+
+    @ReactProp(name = "template")
+    fun setTemplate(view: RCTAppodealNativeView, value: String?) {
+        value?.let { view.template = it }
+    }
+}

--- a/android/src/newarch/com/appodeal/rnappodeal/RNAppodealNativeViewManager.kt
+++ b/android/src/newarch/com/appodeal/rnappodeal/RNAppodealNativeViewManager.kt
@@ -36,8 +36,8 @@ class RNAppodealNativeViewManager :
         value?.let { view.placement = it }
     }
 
-    @ReactProp(name = "template")
-    fun setTemplate(view: RCTAppodealNativeView, value: String?) {
-        value?.let { view.template = it }
+    @ReactProp(name = "adTemplate")
+    fun setAdTemplate(view: RCTAppodealNativeView, value: String?) {
+        value?.let { view.adTemplate = it }
     }
 }

--- a/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealModule.java
+++ b/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealModule.java
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 
 public class RNAppodealModule extends ReactContextBaseJavaModule {
@@ -237,6 +238,31 @@ public class RNAppodealModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void trackEvent(String name, ReadableMap parameters) {
         moduleImplementation.trackEvent(name, parameters);
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public WritableArray getNativeAds(double count) {
+        return moduleImplementation.getNativeAds(count);
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public double getAvailableNativeAdsCount() {
+        return moduleImplementation.getAvailableNativeAdsCount();
+    }
+
+    @ReactMethod
+    public void destroyNativeAd(String adId) {
+        moduleImplementation.destroyNativeAd(adId);
+    }
+
+    @ReactMethod
+    public void cacheNativeAds(double count) {
+        moduleImplementation.cacheNativeAds(count);
+    }
+
+    @ReactMethod
+    public void setPreferredNativeContentType(String type) {
+        moduleImplementation.setPreferredNativeContentType(type);
     }
 
     @ReactMethod

--- a/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealModule.java
+++ b/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealModule.java
@@ -7,7 +7,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 
 public class RNAppodealModule extends ReactContextBaseJavaModule {
@@ -241,7 +240,7 @@ public class RNAppodealModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
-    public WritableArray getNativeAds(double count) {
+    public WritableMap getNativeAds(double count) {
         return moduleImplementation.getNativeAds(count);
     }
 

--- a/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealNativeAdViewManager.java
+++ b/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealNativeAdViewManager.java
@@ -1,0 +1,51 @@
+package com.appodeal.rnappodeal;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
+
+public class RNAppodealNativeAdViewManager extends ViewGroupManager<RCTAppodealNativeAdView> {
+
+    private final RNAppodealNativeAdViewManagerImpl impl = new RNAppodealNativeAdViewManagerImpl();
+
+    @NonNull
+    @Override
+    public String getName() {
+        return RNAppodealNativeAdViewManagerImpl.NAME;
+    }
+
+    @NonNull
+    @Override
+    protected RCTAppodealNativeAdView createViewInstance(@NonNull ThemedReactContext reactContext) {
+        return impl.createViewInstance(reactContext);
+    }
+
+    @Override
+    public void onDropViewInstance(@NonNull RCTAppodealNativeAdView view) {
+        super.onDropViewInstance(view);
+        impl.onDropViewInstance(view);
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return impl.getExportedCustomDirectEventTypeConstants();
+    }
+
+    @ReactProp(name = "adId")
+    public void setAdId(RCTAppodealNativeAdView view, @Nullable String value) {
+        view.setAdId(value);
+    }
+
+    @ReactProp(name = "placement")
+    public void setPlacement(RCTAppodealNativeAdView view, @Nullable String value) {
+        if (value != null) {
+            view.setPlacement(value);
+        }
+    }
+}

--- a/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealNativeAssetViewManager.java
+++ b/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealNativeAssetViewManager.java
@@ -1,0 +1,38 @@
+package com.appodeal.rnappodeal;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+public class RNAppodealNativeAssetViewManager extends SimpleViewManager<RCTAppodealNativeAssetView> {
+
+    private final RNAppodealNativeAssetViewManagerImpl impl = new RNAppodealNativeAssetViewManagerImpl();
+
+    @NonNull
+    @Override
+    public String getName() {
+        return RNAppodealNativeAssetViewManagerImpl.NAME;
+    }
+
+    @NonNull
+    @Override
+    protected RCTAppodealNativeAssetView createViewInstance(@NonNull ThemedReactContext reactContext) {
+        return impl.createViewInstance(reactContext);
+    }
+
+    @Override
+    public void onDropViewInstance(@NonNull RCTAppodealNativeAssetView view) {
+        super.onDropViewInstance(view);
+        impl.onDropViewInstance(view);
+    }
+
+    @ReactProp(name = "asset")
+    public void setAsset(RCTAppodealNativeAssetView view, @Nullable String value) {
+        if (value != null) {
+            view.setAssetType(value);
+        }
+    }
+}

--- a/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealNativeViewManager.java
+++ b/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealNativeViewManager.java
@@ -53,10 +53,10 @@ public class RNAppodealNativeViewManager extends SimpleViewManager<RCTAppodealNa
         }
     }
 
-    @ReactProp(name = "template")
-    public void setTemplate(RCTAppodealNativeView view, @Nullable String value) {
+    @ReactProp(name = "adTemplate")
+    public void setAdTemplate(RCTAppodealNativeView view, @Nullable String value) {
         if (value != null) {
-            view.setTemplate(value);
+            view.setAdTemplate(value);
         }
     }
 }

--- a/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealNativeViewManager.java
+++ b/android/src/oldarch/com/appodeal/rnappodeal/RNAppodealNativeViewManager.java
@@ -1,0 +1,62 @@
+package com.appodeal.rnappodeal;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
+
+public class RNAppodealNativeViewManager extends SimpleViewManager<RCTAppodealNativeView> {
+
+    private final RNAppodealNativeViewManagerImpl nativeViewManagerImpl;
+
+    public RNAppodealNativeViewManager() {
+        this.nativeViewManagerImpl = new RNAppodealNativeViewManagerImpl();
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return RNAppodealNativeViewManagerImpl.NAME;
+    }
+
+    @NonNull
+    @Override
+    protected RCTAppodealNativeView createViewInstance(@NonNull ThemedReactContext reactContext) {
+        return nativeViewManagerImpl.createViewInstance(reactContext);
+    }
+
+    @Override
+    public void onDropViewInstance(@NonNull RCTAppodealNativeView view) {
+        super.onDropViewInstance(view);
+        nativeViewManagerImpl.onDropViewInstance(view);
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return nativeViewManagerImpl.getExportedCustomDirectEventTypeConstants();
+    }
+
+    @ReactProp(name = "adId")
+    public void setAdId(RCTAppodealNativeView view, @Nullable String value) {
+        view.setAdId(value);
+    }
+
+    @ReactProp(name = "placement")
+    public void setPlacement(RCTAppodealNativeView view, @Nullable String value) {
+        if (value != null) {
+            view.setPlacement(value);
+        }
+    }
+
+    @ReactProp(name = "template")
+    public void setTemplate(RCTAppodealNativeView view, @Nullable String value) {
+        if (value != null) {
+            view.setTemplate(value);
+        }
+    }
+}

--- a/ios/RNADefines.h
+++ b/ios/RNADefines.h
@@ -38,6 +38,16 @@ FOUNDATION_EXPORT NSString *const kEventInterstitialClosed;
 FOUNDATION_EXPORT NSString *const kEventInterstitialClicked;
 
 /**
+ * Native ad events
+ */
+FOUNDATION_EXPORT NSString *const kEventNativeLoaded;
+FOUNDATION_EXPORT NSString *const kEventNativeFailedToLoad;
+FOUNDATION_EXPORT NSString *const kEventNativeShown;
+FOUNDATION_EXPORT NSString *const kEventNativeShowFailed;
+FOUNDATION_EXPORT NSString *const kEventNativeClicked;
+FOUNDATION_EXPORT NSString *const kEventNativeExpired;
+
+/**
  * Rewarded video ad events
  */
 FOUNDATION_EXPORT NSString *const kEventRewardedVideoLoaded;

--- a/ios/RNADefines.m
+++ b/ios/RNADefines.m
@@ -27,6 +27,14 @@ NSString *const kEventInterstitialShown             = @"onInterstitialShown";
 NSString *const kEventInterstitialClosed            = @"onInterstitialClosed";
 NSString *const kEventInterstitialClicked           = @"onInterstitialClicked";
 
+// Native ad events
+NSString *const kEventNativeLoaded                  = @"onNativeLoaded";
+NSString *const kEventNativeFailedToLoad            = @"onNativeFailedToLoad";
+NSString *const kEventNativeShown                     = @"onNativeShown";
+NSString *const kEventNativeShowFailed                = @"onNativeShowFailed";
+NSString *const kEventNativeClicked                   = @"onNativeClicked";
+NSString *const kEventNativeExpired                   = @"onNativeExpired";
+
 // Rewarded video ad events
 NSString *const kEventRewardedVideoLoaded           = @"onRewardedVideoLoaded";
 NSString *const kEventRewardedVideoFailedToLoad     = @"onRewardedVideoFailedToLoad";
@@ -101,6 +109,14 @@ NSArray<NSString *> *RNASupportedMethods(void) {
         kEventInterstitialExpired,
         kEventInterstitialClosed,
         kEventInterstitialClicked,
+
+        // Native events
+        kEventNativeLoaded,
+        kEventNativeFailedToLoad,
+        kEventNativeShown,
+        kEventNativeShowFailed,
+        kEventNativeClicked,
+        kEventNativeExpired,
         
         // Rewarded video events
         kEventRewardedVideoLoaded,

--- a/ios/RNAppodeal.mm
+++ b/ios/RNAppodeal.mm
@@ -2,6 +2,7 @@
 #import "RNADefines.h"
 #import "RNAEventDispatcher.h"
 #import "RNAppodealBannerView.h"
+#import "RNAppodealNativeAdStore.h"
 #import <React/RCTUtils.h>
 #import <StackConsentManager/StackConsentManager-Swift.h>
 
@@ -58,6 +59,10 @@ RCT_EXPORT_MODULE();
     
     [Appodeal initializeWithApiKey:appKey
                              types:AppodealAdTypeFromRNAAdType(adTypes)];
+
+    if (((NSInteger)adTypes & RNAAdTypeNative) > 0) {
+        [[RNAppodealNativeAdStore shared] ensureQueue];
+    }
 }
 
 #ifndef RCT_NEW_ARCH_ENABLED
@@ -85,6 +90,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isLoaded:(double)showType) {
     // MREC is not represented in the central SDK manager on iOS; query the view. See APDM-2627.
     if ((NSInteger)showType == RNAAdTypeMREC) {
         return @([RNAppodealMrecView isActiveMrecReady]);
+    }
+    if ((NSInteger)showType == RNAAdTypeNative) {
+        return @([[RNAppodealNativeAdStore shared] availableCount] > 0);
     }
     BOOL isLoaded = [Appodeal isReadyForShowWithStyle:AppodealShowStyleFromRNAAdType(showType)];
     return @(isLoaded);
@@ -117,6 +125,28 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(canShow:(double)showType
     BOOL canShow = [Appodeal canShow:AppodealAdTypeFromRNAAdType(showType)
                         forPlacement:placement];
     return @(canShow);
+}
+
+#pragma mark - Native Ads
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getNativeAds:(double)count) {
+    return [[RNAppodealNativeAdStore shared] getNativeAds:(NSInteger)count];
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getAvailableNativeAdsCount) {
+    return @([[RNAppodealNativeAdStore shared] availableCount]);
+}
+
+RCT_EXPORT_METHOD(destroyNativeAd:(NSString *)adId) {
+    [[RNAppodealNativeAdStore shared] destroyAdId:adId];
+}
+
+RCT_EXPORT_METHOD(cacheNativeAds:(double)count) {
+    [[RNAppodealNativeAdStore shared] cacheNativeAds:(NSInteger)count];
+}
+
+RCT_EXPORT_METHOD(setPreferredNativeContentType:(NSString *)type) {
+    [[RNAppodealNativeAdStore shared] setPreferredType:type];
 }
 
 #pragma mark - Banner Settings
@@ -440,6 +470,9 @@ RCT_EXPORT_METHOD(setSharedAdsInstanceAcrossActivities:(BOOL)flag) {}
     if ((NSInteger)showType == RNAAdTypeMREC) {
         return @([RNAppodealMrecView isActiveMrecReady]);
     }
+    if ((NSInteger)showType == RNAAdTypeNative) {
+        return @([[RNAppodealNativeAdStore shared] availableCount] > 0);
+    }
     BOOL isLoaded = [Appodeal isReadyForShowWithStyle:AppodealShowStyleFromRNAAdType(showType)];
     return @(isLoaded);
 }
@@ -470,6 +503,28 @@ RCT_EXPORT_METHOD(setSharedAdsInstanceAcrossActivities:(BOOL)flag) {}
 
 - (NSNumber *)isPrecache:(double)adTypes {
     return @([Appodeal isPrecacheAd:AppodealAdTypeFromRNAAdType(adTypes)]);
+}
+
+#pragma mark - Native Ads
+
+- (NSArray *)getNativeAds:(double)count {
+    return [[RNAppodealNativeAdStore shared] getNativeAds:(NSInteger)count];
+}
+
+- (NSNumber *)getAvailableNativeAdsCount {
+    return @([[RNAppodealNativeAdStore shared] availableCount]);
+}
+
+- (void)destroyNativeAd:(NSString *)adId {
+    [[RNAppodealNativeAdStore shared] destroyAdId:adId];
+}
+
+- (void)cacheNativeAds:(double)count {
+    [[RNAppodealNativeAdStore shared] cacheNativeAds:(NSInteger)count];
+}
+
+- (void)setPreferredNativeContentType:(NSString *)type {
+    [[RNAppodealNativeAdStore shared] setPreferredType:type];
 }
 
 #pragma mark - Banner Settings

--- a/ios/RNAppodealNativeAdStore.h
+++ b/ios/RNAppodealNativeAdStore.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+#import <Appodeal/Appodeal.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNAppodealNativeAdStore : NSObject <APDNativeAdQueueDelegate>
+
++ (instancetype)shared;
+
+- (void)ensureQueue;
+- (NSArray<NSDictionary *> *)getNativeAds:(NSInteger)count;
+- (NSInteger)availableCount;
+- (nullable APDNativeAd *)nativeAdForId:(NSString *)adId;
+- (void)destroyAdId:(NSString *)adId;
+- (void)setPreferredType:(NSString *)type;
+- (void)setAdViewTemplateClass:(Class)templateClass;
+- (void)cacheNativeAds:(NSInteger)count;
+- (void)emitNativeEvent:(NSString *)eventName payload:(nullable NSDictionary *)payload;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNAppodealNativeAdStore.m
+++ b/ios/RNAppodealNativeAdStore.m
@@ -1,0 +1,185 @@
+#import "RNAppodealNativeAdStore.h"
+#import "RNADefines.h"
+#import "RNAEventDispatcher.h"
+
+@interface RNAppodealNativeAdStore ()
+
+@property (nonatomic, strong, nullable) APDNativeAdQueue *queue;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, APDNativeAd *> *adsById;
+@property (nonatomic, copy) NSString *preferredContentType;
+
+@end
+
+@implementation RNAppodealNativeAdStore
+
++ (instancetype)shared {
+    static RNAppodealNativeAdStore *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] init];
+    });
+    return sharedInstance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _adsById = [NSMutableDictionary dictionary];
+        _preferredContentType = @"auto";
+    }
+    return self;
+}
+
+#pragma mark - Queue lifecycle
+
+- (void)ensureQueue {
+    if (self.queue != nil) {
+        return;
+    }
+
+    APDNativeAdQueue *queue = [[APDNativeAdQueue alloc] init];
+    if ([APDNativeAdSettings respondsToSelector:@selector(defaultSettings)]) {
+        queue.settings = [APDNativeAdSettings defaultSettings];
+    } else if ([APDNativeAdSettings respondsToSelector:@selector(default)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        queue.settings = [APDNativeAdSettings performSelector:@selector(default)];
+#pragma clang diagnostic pop
+    } else {
+        queue.settings = [[APDNativeAdSettings alloc] init];
+    }
+    queue.settings.adViewClass = APDDefaultNativeAdView.class;
+    queue.settings.type = [self nativeAdTypeFromPreferredContentType:self.preferredContentType];
+    queue.delegate = self;
+
+    self.queue = queue;
+    [self.queue loadAd];
+}
+
+- (APDNativeAdType)nativeAdTypeFromPreferredContentType:(NSString *)type {
+    if ([type isEqualToString:@"noVideo"]) {
+        return APDNativeAdTypeNoVideo;
+    }
+    if ([type isEqualToString:@"video"]) {
+        return APDNativeAdTypeVideo;
+    }
+    return APDNativeAdTypeAuto;
+}
+
+- (void)setPreferredType:(NSString *)type {
+    self.preferredContentType = type ?: @"auto";
+
+    if (self.queue != nil) {
+        self.queue.settings.type = [self nativeAdTypeFromPreferredContentType:self.preferredContentType];
+    }
+}
+
+- (void)setAdViewTemplateClass:(Class)templateClass {
+    [self ensureQueue];
+
+    if (templateClass != Nil) {
+        self.queue.settings.adViewClass = templateClass;
+    } else {
+        self.queue.settings.adViewClass = APDDefaultNativeAdView.class;
+    }
+}
+
+- (void)cacheNativeAds:(NSInteger)count {
+    [self ensureQueue];
+
+    if ([self.queue respondsToSelector:@selector(setMaxAdSize:)]) {
+        [self.queue setMaxAdSize:count];
+    }
+
+    [self.queue loadAd];
+}
+
+#pragma mark - Ad access
+
+- (NSInteger)availableCount {
+    if (self.queue == nil) {
+        return 0;
+    }
+
+    if ([self.queue respondsToSelector:@selector(availableAdsCount)]) {
+        return self.queue.availableAdsCount;
+    }
+
+    if ([self.queue respondsToSelector:@selector(currentAdCount)]) {
+        return self.queue.currentAdCount;
+    }
+
+    return (NSInteger)[Appodeal availableNativeAdsCount];
+}
+
+- (NSArray<NSDictionary *> *)getNativeAds:(NSInteger)count {
+    [self ensureQueue];
+
+    if (count <= 0) {
+        return @[];
+    }
+
+    NSArray<APDNativeAd *> *nativeAds = [self.queue getNativeAdsOfCount:count];
+    NSMutableArray<NSDictionary *> *result = [NSMutableArray arrayWithCapacity:nativeAds.count];
+
+    for (APDNativeAd *nativeAd in nativeAds) {
+        NSString *adId = [[NSUUID UUID] UUIDString];
+        self.adsById[adId] = nativeAd;
+
+        NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+        payload[@"id"] = adId;
+        payload[@"title"] = nativeAd.title ?: @"";
+        payload[@"description"] = nativeAd.descriptionText ?: @"";
+        payload[@"callToAction"] = nativeAd.callToActionText ?: @"";
+        payload[@"rating"] = nativeAd.starRating ?: @0;
+        payload[@"containsVideo"] = @(nativeAd.containsVideo);
+        payload[@"predictedEcpm"] = @([Appodeal predictedEcpmForAdType:AppodealAdTypeNativeAd]);
+
+        [result addObject:payload];
+    }
+
+    return result;
+}
+
+- (APDNativeAd *)nativeAdForId:(NSString *)adId {
+    if (adId.length == 0) {
+        return nil;
+    }
+    return self.adsById[adId];
+}
+
+- (void)destroyAdId:(NSString *)adId {
+    if (adId.length == 0) {
+        return;
+    }
+
+    APDNativeAd *nativeAd = self.adsById[adId];
+    if (nativeAd != nil) {
+        [nativeAd detachFromView];
+        nativeAd.delegate = nil;
+    }
+
+    [self.adsById removeObjectForKey:adId];
+}
+
+#pragma mark - Events
+
+- (void)emitNativeEvent:(NSString *)eventName payload:(nullable NSDictionary *)payload {
+    [[RNAEventDispatcher sharedDispatcher] dispatchEvent:eventName payload:payload];
+}
+
+#pragma mark - APDNativeAdQueueDelegate
+
+- (void)adQueueAdIsAvailable:(APDNativeAdQueue *)adQueue ofCount:(NSInteger)count {
+    [self emitNativeEvent:kEventNativeLoaded payload:@{@"count": @(count)}];
+}
+
+- (void)adQueue:(APDNativeAdQueue *)adQueue failedWithError:(NSError *)error {
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    if (error.localizedDescription.length > 0) {
+        payload[@"message"] = error.localizedDescription;
+    }
+    [self emitNativeEvent:kEventNativeFailedToLoad payload:payload.count > 0 ? payload : nil];
+}
+
+@end

--- a/ios/RNAppodealNativeAdStore.m
+++ b/ios/RNAppodealNativeAdStore.m
@@ -38,16 +38,8 @@
     }
 
     APDNativeAdQueue *queue = [[APDNativeAdQueue alloc] init];
-    if ([APDNativeAdSettings respondsToSelector:@selector(defaultSettings)]) {
-        queue.settings = [APDNativeAdSettings defaultSettings];
-    } else if ([APDNativeAdSettings respondsToSelector:@selector(default)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        queue.settings = [APDNativeAdSettings performSelector:@selector(default)];
-#pragma clang diagnostic pop
-    } else {
-        queue.settings = [[APDNativeAdSettings alloc] init];
-    }
+    // Appodeal iOS docs: APDNativeAdSettings.default()
+    queue.settings = [APDNativeAdSettings default];
     queue.settings.adViewClass = APDDefaultNativeAdView.class;
     queue.settings.type = [self nativeAdTypeFromPreferredContentType:self.preferredContentType];
     queue.delegate = self;
@@ -101,10 +93,7 @@
         return 0;
     }
 
-    if ([self.queue respondsToSelector:@selector(availableAdsCount)]) {
-        return self.queue.availableAdsCount;
-    }
-
+    // APDNativeAdQueue exposes currentAdCount; Appodeal also has availableNativeAdsCount.
     if ([self.queue respondsToSelector:@selector(currentAdCount)]) {
         return self.queue.currentAdCount;
     }

--- a/ios/RNAppodealNativeAdView.h
+++ b/ios/RNAppodealNativeAdView.h
@@ -1,0 +1,24 @@
+#import <React/RCTView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Composable native ad root (AdMob-style).
+ * Asset children are RNAppodealNativeAssetView instances.
+ */
+@interface RNAppodealNativeAdView : RCTView
+
+@property (nonatomic, copy, nullable) NSString *adId;
+@property (nonatomic, copy) NSString *placement;
+
+@property (nonatomic, copy) RCTBubblingEventBlock onAdLoaded;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdFailedToLoad;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdClicked;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdExpired;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdShown;
+
+- (void)onAssetChanged;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNAppodealNativeAdView.m
+++ b/ios/RNAppodealNativeAdView.m
@@ -1,0 +1,237 @@
+#import "RNAppodealNativeAdView.h"
+#import "RNAppodealNativeAssetView.h"
+#import "RNAppodealNativeAdStore.h"
+#import "RNADefines.h"
+
+#import <React/RCTLog.h>
+#import <React/RCTUtils.h>
+#import <Appodeal/Appodeal.h>
+
+@interface RNAppodealNativeAdView () <APDNativeAdPresentationDelegate>
+@property (nonatomic, strong, nullable) APDNativeAd *nativeAd;
+@property (nonatomic, strong, nullable) UIView *mediaView;
+@property (nonatomic, copy, nullable) NSString *boundAdId;
+@end
+
+@implementation RNAppodealNativeAdView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        self.backgroundColor = UIColor.clearColor;
+        _placement = @"default";
+        self.clipsToBounds = NO;
+    }
+    return self;
+}
+
+- (void)setAdId:(NSString *)adId {
+    if ([_adId isEqualToString:adId]) {
+        return;
+    }
+    _adId = [adId copy];
+    self.boundAdId = nil;
+    [self bindNativeAd];
+}
+
+- (void)setPlacement:(NSString *)placement {
+    _placement = placement.length > 0 ? [placement copy] : @"default";
+    if (self.boundAdId != nil) {
+        self.boundAdId = nil;
+        [self bindNativeAd];
+    }
+}
+
+- (void)onAssetChanged {
+    self.boundAdId = nil;
+    [self bindNativeAd];
+}
+
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    if (self.window != nil && self.boundAdId == nil && self.adId.length > 0) {
+        [self bindNativeAd];
+    }
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.mediaView.frame = self.mediaAsset.mediaContainer.bounds;
+    if (self.boundAdId == nil && self.adId.length > 0 && CGRectGetWidth(self.bounds) > 0) {
+        [self bindNativeAd];
+    }
+}
+
+- (void)clearBinding {
+    if (self.nativeAd != nil) {
+        [self.nativeAd detachFromView];
+        self.nativeAd.delegate = nil;
+        self.nativeAd = nil;
+    }
+    [self.mediaView removeFromSuperview];
+    self.mediaView = nil;
+    self.boundAdId = nil;
+}
+
+- (void)bindNativeAd {
+    if (self.adId.length == 0) {
+        return;
+    }
+    if ([self.boundAdId isEqualToString:self.adId]) {
+        return;
+    }
+    if (self.window == nil || CGRectGetWidth(self.bounds) <= 0 || CGRectGetHeight(self.bounds) <= 0) {
+        return;
+    }
+
+    [self clearBinding];
+
+    APDNativeAd *nativeAd = [[RNAppodealNativeAdStore shared] nativeAdForId:self.adId];
+    if (nativeAd == nil) {
+        if (self.onAdFailedToLoad) {
+            self.onAdFailedToLoad(@{@"adId": self.adId ?: @"", @"message": @"native ad not in store"});
+        }
+        return;
+    }
+
+    RNAppodealNativeAssetView *titleAsset = [self assetWithType:@"title"];
+    RNAppodealNativeAssetView *descriptionAsset = [self assetWithType:@"description"];
+    RNAppodealNativeAssetView *ctaAsset = [self assetWithType:@"callToAction"];
+    RNAppodealNativeAssetView *attributionAsset = [self assetWithType:@"attribution"];
+    RNAppodealNativeAssetView *iconAsset = [self assetWithType:@"icon"];
+    RNAppodealNativeAssetView *mediaAsset = [self assetWithType:@"media"];
+
+    if (mediaAsset == nil && iconAsset == nil) {
+        if (self.onAdFailedToLoad) {
+            self.onAdFailedToLoad(@{
+                @"adId": self.adId ?: @"",
+                @"message": @"composable native ad requires media or icon asset"
+            });
+        }
+        return;
+    }
+
+    // Fill text/image assets from the ad object (iOS custom path fills via
+    // APDNativeAdView outlets; here RN owns the views so we copy fields).
+    titleAsset.textLabel.text = nativeAd.title ?: @"";
+    descriptionAsset.textLabel.text = nativeAd.descriptionText ?: @"";
+    ctaAsset.textLabel.text = nativeAd.callToActionText ?: @"";
+    if (attributionAsset.textLabel.text.length == 0) {
+        attributionAsset.textLabel.text = @"Ad";
+    }
+
+    if (iconAsset.iconImageView != nil && nativeAd.iconImage != nil) {
+        if ([nativeAd.iconImage respondsToSelector:@selector(image)]) {
+            iconAsset.iconImageView.image = [nativeAd.iconImage performSelector:@selector(image)];
+        }
+    }
+
+    UIViewController *rootViewController = RCTPresentedViewController();
+    if (rootViewController == nil) {
+        if (self.onAdFailedToLoad) {
+            self.onAdFailedToLoad(@{@"adId": self.adId ?: @"", @"message": @"root view controller unavailable"});
+        }
+        return;
+    }
+
+    // Media: prefer APDMediaView when available (Appodeal iOS media container).
+    if (mediaAsset.mediaContainer != nil) {
+        Class mediaClass = NSClassFromString(@"APDMediaView");
+        if (mediaClass != Nil) {
+            UIView *media = [[mediaClass alloc] initWithFrame:mediaAsset.mediaContainer.bounds];
+            media.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+            [mediaAsset.mediaContainer addSubview:media];
+            self.mediaView = media;
+            if ([media respondsToSelector:@selector(setNativeAd:rootViewController:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                [media performSelector:@selector(setNativeAd:rootViewController:)
+                            withObject:nativeAd
+                            withObject:rootViewController];
+#pragma clang diagnostic pop
+            } else if ([media respondsToSelector:@selector(setNativeAd:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                [media performSelector:@selector(setNativeAd:) withObject:nativeAd];
+#pragma clang diagnostic pop
+            }
+        } else if (nativeAd.mainImage != nil && [nativeAd.mainImage respondsToSelector:@selector(image)]) {
+            UIImageView *imageView = [[UIImageView alloc] initWithFrame:mediaAsset.mediaContainer.bounds];
+            imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+            imageView.contentMode = UIViewContentModeScaleAspectFit;
+            imageView.image = [nativeAd.mainImage performSelector:@selector(image)];
+            [mediaAsset.mediaContainer addSubview:imageView];
+            self.mediaView = imageView;
+        }
+    }
+
+    self.nativeAd = nativeAd;
+    self.nativeAd.delegate = self;
+
+    // Register the RN-composed hierarchy for impressions / clicks.
+    // Pair of detachFromView used in RNAppodealNativeAdStore.
+    if ([nativeAd respondsToSelector:@selector(attachToView:withRootViewController:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [nativeAd performSelector:@selector(attachToView:withRootViewController:)
+                       withObject:self
+                       withObject:rootViewController];
+#pragma clang diagnostic pop
+    } else if ([nativeAd respondsToSelector:@selector(attachToView:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [nativeAd performSelector:@selector(attachToView:) withObject:self];
+#pragma clang diagnostic pop
+    }
+
+    self.boundAdId = self.adId;
+    if (self.onAdLoaded) {
+        self.onAdLoaded(@{@"adId": self.adId ?: @""});
+    }
+}
+
+- (RNAppodealNativeAssetView *)mediaAsset {
+    return [self assetWithType:@"media"];
+}
+
+- (RNAppodealNativeAssetView *)assetWithType:(NSString *)type {
+    return [self findAsset:type inView:self];
+}
+
+- (RNAppodealNativeAssetView *)findAsset:(NSString *)type inView:(UIView *)view {
+    if ([view isKindOfClass:[RNAppodealNativeAssetView class]]) {
+        RNAppodealNativeAssetView *assetView = (RNAppodealNativeAssetView *)view;
+        if ([assetView.asset isEqualToString:type]) {
+            return assetView;
+        }
+    }
+    for (UIView *child in view.subviews) {
+        RNAppodealNativeAssetView *found = [self findAsset:type inView:child];
+        if (found != nil) {
+            return found;
+        }
+    }
+    return nil;
+}
+
+- (void)removeFromSuperview {
+    [self clearBinding];
+    [super removeFromSuperview];
+}
+
+#pragma mark - APDNativeAdPresentationDelegate
+
+- (void)nativeAdWillLogImpression:(APDNativeAd *)nativeAd {
+    if (self.onAdShown) {
+        self.onAdShown(@{@"adId": self.adId ?: @""});
+    }
+    [[RNAppodealNativeAdStore shared] emitNativeEvent:kEventNativeShown payload:@{@"adId": self.adId ?: @""}];
+}
+
+- (void)nativeAdWillLogUserInteraction:(APDNativeAd *)nativeAd {
+    if (self.onAdClicked) {
+        self.onAdClicked(@{@"adId": self.adId ?: @""});
+    }
+    [[RNAppodealNativeAdStore shared] emitNativeEvent:kEventNativeClicked payload:@{@"adId": self.adId ?: @""}];
+}
+
+@end

--- a/ios/RNAppodealNativeAdViewManager.mm
+++ b/ios/RNAppodealNativeAdViewManager.mm
@@ -1,0 +1,23 @@
+#import <React/RCTViewManager.h>
+#import "RNAppodealNativeAdView.h"
+
+@interface RNAppodealNativeAdViewManager : RCTViewManager
+@end
+
+@implementation RNAppodealNativeAdViewManager
+
+RCT_EXPORT_MODULE(RNAppodealNativeAdView)
+
+- (UIView *)view {
+    return [[RNAppodealNativeAdView alloc] initWithFrame:CGRectZero];
+}
+
+RCT_EXPORT_VIEW_PROPERTY(adId, NSString)
+RCT_EXPORT_VIEW_PROPERTY(placement, NSString)
+RCT_EXPORT_VIEW_PROPERTY(onAdLoaded, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdFailedToLoad, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdClicked, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdExpired, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdShown, RCTBubblingEventBlock)
+
+@end

--- a/ios/RNAppodealNativeAssetView.h
+++ b/ios/RNAppodealNativeAssetView.h
@@ -1,0 +1,19 @@
+#import <React/RCTView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Single native-ad asset marker.
+ * asset: media | icon | title | description | callToAction | attribution
+ */
+@interface RNAppodealNativeAssetView : RCTView
+
+@property (nonatomic, copy) NSString *asset;
+
+@property (nonatomic, strong, readonly) UILabel *textLabel;
+@property (nonatomic, strong, readonly) UIImageView *iconImageView;
+@property (nonatomic, strong, readonly) UIView *mediaContainer;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNAppodealNativeAssetView.m
+++ b/ios/RNAppodealNativeAssetView.m
@@ -1,0 +1,83 @@
+#import "RNAppodealNativeAssetView.h"
+
+@interface RNAppodealNativeAssetView ()
+@property (nonatomic, strong, readwrite) UILabel *textLabel;
+@property (nonatomic, strong, readwrite) UIImageView *iconImageView;
+@property (nonatomic, strong, readwrite) UIView *mediaContainer;
+@end
+
+@implementation RNAppodealNativeAssetView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        _asset = @"title";
+        self.clipsToBounds = NO;
+        [self rebuildContent];
+    }
+    return self;
+}
+
+- (void)setAsset:(NSString *)asset {
+    NSString *normalized = asset.length > 0 ? asset : @"title";
+    if ([_asset isEqualToString:normalized]) {
+        return;
+    }
+    _asset = [normalized copy];
+    [self rebuildContent];
+
+    UIView *parent = self.superview;
+    while (parent != nil) {
+        if ([parent respondsToSelector:@selector(onAssetChanged)]) {
+            [parent performSelector:@selector(onAssetChanged)];
+            break;
+        }
+        parent = parent.superview;
+    }
+}
+
+- (void)rebuildContent {
+    [self.textLabel removeFromSuperview];
+    [self.iconImageView removeFromSuperview];
+    [self.mediaContainer removeFromSuperview];
+    self.textLabel = nil;
+    self.iconImageView = nil;
+    self.mediaContainer = nil;
+
+    if ([self.asset isEqualToString:@"media"]) {
+        UIView *container = [[UIView alloc] initWithFrame:self.bounds];
+        container.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        container.clipsToBounds = YES;
+        [self addSubview:container];
+        self.mediaContainer = container;
+        return;
+    }
+
+    if ([self.asset isEqualToString:@"icon"]) {
+        UIImageView *imageView = [[UIImageView alloc] initWithFrame:self.bounds];
+        imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        imageView.contentMode = UIViewContentModeScaleAspectFit;
+        imageView.clipsToBounds = YES;
+        [self addSubview:imageView];
+        self.iconImageView = imageView;
+        return;
+    }
+
+    UILabel *label = [[UILabel alloc] initWithFrame:self.bounds];
+    label.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    label.numberOfLines = [self.asset isEqualToString:@"title"] ? 2 : 1;
+    label.lineBreakMode = NSLineBreakByTruncatingTail;
+    if ([self.asset isEqualToString:@"callToAction"] || [self.asset isEqualToString:@"attribution"]) {
+        label.textAlignment = NSTextAlignmentCenter;
+    }
+    [self addSubview:label];
+    self.textLabel = label;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.textLabel.frame = self.bounds;
+    self.iconImageView.frame = self.bounds;
+    self.mediaContainer.frame = self.bounds;
+}
+
+@end

--- a/ios/RNAppodealNativeAssetViewManager.mm
+++ b/ios/RNAppodealNativeAssetViewManager.mm
@@ -1,0 +1,17 @@
+#import <React/RCTViewManager.h>
+#import "RNAppodealNativeAssetView.h"
+
+@interface RNAppodealNativeAssetViewManager : RCTViewManager
+@end
+
+@implementation RNAppodealNativeAssetViewManager
+
+RCT_EXPORT_MODULE(RNAppodealNativeAssetView)
+
+- (UIView *)view {
+    return [[RNAppodealNativeAssetView alloc] initWithFrame:CGRectZero];
+}
+
+RCT_EXPORT_VIEW_PROPERTY(asset, NSString)
+
+@end

--- a/ios/RNAppodealNativeView.h
+++ b/ios/RNAppodealNativeView.h
@@ -1,0 +1,19 @@
+#import <React/RCTView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNAppodealNativeView : RCTView
+
+@property (nonatomic, copy, nullable) NSString *adId;
+@property (nonatomic, copy) NSString *placement;
+@property (nonatomic, copy, nullable) NSString *templateName;
+
+@property (nonatomic, copy) RCTBubblingEventBlock onAdLoaded;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdFailedToLoad;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdClicked;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdExpired;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdShown;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNAppodealNativeView.m
+++ b/ios/RNAppodealNativeView.m
@@ -1,0 +1,157 @@
+#import "RNAppodealNativeView.h"
+#import "RNAppodealNativeAdStore.h"
+#import "RNADefines.h"
+
+#import <React/RCTLog.h>
+#import <React/RCTUtils.h>
+#import <Appodeal/Appodeal.h>
+
+@interface RNAppodealNativeView () <APDNativeAdPresentationDelegate>
+
+@property (nonatomic, strong, nullable) APDNativeAd *nativeAd;
+@property (nonatomic, strong, nullable) UIView *adContentView;
+
+@end
+
+@implementation RNAppodealNativeView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        self.backgroundColor = UIColor.clearColor;
+        _placement = @"default";
+    }
+    return self;
+}
+
+- (void)setAdId:(NSString *)adId {
+    if ([_adId isEqualToString:adId]) {
+        return;
+    }
+
+    _adId = [adId copy];
+    [self reloadNativeAdView];
+}
+
+- (void)setPlacement:(NSString *)placement {
+    _placement = placement.length > 0 ? [placement copy] : @"default";
+
+    if (self.adContentView != nil) {
+        [self reloadNativeAdView];
+    }
+}
+
+- (void)setTemplateName:(NSString *)templateName {
+    _templateName = [templateName copy];
+
+    if (self.adContentView != nil) {
+        [self reloadNativeAdView];
+    }
+}
+
+- (void)reloadNativeAdView {
+    [self clearNativeAdView];
+
+    if (self.adId.length == 0) {
+        return;
+    }
+
+    NSAssert([Appodeal isInitializedForAdType:AppodealAdTypeNativeAd],
+             @"Appodeal should be initialised with AppodealAdTypeNativeAd before trying to add RNAppodealNativeView in hierarchy");
+
+    APDNativeAd *nativeAd = [[RNAppodealNativeAdStore shared] nativeAdForId:self.adId];
+    if (nativeAd == nil) {
+        if (self.onAdFailedToLoad) {
+            self.onAdFailedToLoad(@{});
+        }
+        [[RNAppodealNativeAdStore shared] emitNativeEvent:kEventNativeShowFailed payload:@{@"adId": self.adId}];
+        return;
+    }
+
+    [self applyTemplateIfNeeded];
+
+    self.nativeAd = nativeAd;
+    self.nativeAd.delegate = self;
+
+    UIViewController *rootViewController = RCTPresentedViewController();
+    NSError *error = nil;
+    UIView *adView = [nativeAd getViewForPlacement:self.placement
+                              withRootViewController:rootViewController
+                                               error:&error];
+
+    if (adView == nil || error != nil) {
+        if (self.onAdFailedToLoad) {
+            self.onAdFailedToLoad(@{});
+        }
+
+        NSMutableDictionary *payload = [NSMutableDictionary dictionaryWithObject:self.adId forKey:@"adId"];
+        if (error.localizedDescription.length > 0) {
+            payload[@"message"] = error.localizedDescription;
+        }
+        [[RNAppodealNativeAdStore shared] emitNativeEvent:kEventNativeShowFailed payload:payload];
+        return;
+    }
+
+    self.adContentView = adView;
+    self.adContentView.frame = self.bounds;
+    self.adContentView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self addSubview:self.adContentView];
+
+    if (self.onAdLoaded) {
+        self.onAdLoaded(@{@"adId": self.adId});
+    }
+}
+
+- (void)applyTemplateIfNeeded {
+    [[RNAppodealNativeAdStore shared] ensureQueue];
+
+    if (self.templateName.length == 0 || [self.templateName isEqualToString:@"default"]) {
+        [[RNAppodealNativeAdStore shared] setAdViewTemplateClass:APDDefaultNativeAdView.class];
+        return;
+    }
+
+    Class templateClass = NSClassFromString(self.templateName);
+    [[RNAppodealNativeAdStore shared] setAdViewTemplateClass:templateClass != Nil ? templateClass : APDDefaultNativeAdView.class];
+}
+
+- (void)clearNativeAdView {
+    if (self.nativeAd != nil) {
+        [self.nativeAd detachFromView];
+        self.nativeAd.delegate = nil;
+        self.nativeAd = nil;
+    }
+
+    [self.adContentView removeFromSuperview];
+    self.adContentView = nil;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.adContentView.frame = self.bounds;
+}
+
+- (void)removeFromSuperview {
+    [self clearNativeAdView];
+    [super removeFromSuperview];
+}
+
+- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex {
+    RCTLogError(@"RNAppodealNativeView cannot have subviews");
+}
+
+#pragma mark - APDNativeAdPresentationDelegate
+
+- (void)nativeAdWillLogImpression:(APDNativeAd *)nativeAd {
+    if (self.onAdShown) {
+        self.onAdShown(@{@"adId": self.adId ?: @""});
+    }
+    [[RNAppodealNativeAdStore shared] emitNativeEvent:kEventNativeShown payload:@{@"adId": self.adId ?: @""}];
+}
+
+- (void)nativeAdWillLogUserInteraction:(APDNativeAd *)nativeAd {
+    if (self.onAdClicked) {
+        self.onAdClicked(@{@"adId": self.adId ?: @""});
+    }
+    [[RNAppodealNativeAdStore shared] emitNativeEvent:kEventNativeClicked payload:@{@"adId": self.adId ?: @""}];
+}
+
+@end

--- a/ios/RNAppodealNativeViewManager.h
+++ b/ios/RNAppodealNativeViewManager.h
@@ -1,0 +1,5 @@
+#import <React/RCTViewManager.h>
+
+@interface RNAppodealNativeViewManager : RCTViewManager
+
+@end

--- a/ios/RNAppodealNativeViewManager.mm
+++ b/ios/RNAppodealNativeViewManager.mm
@@ -1,0 +1,22 @@
+#import "RNAppodealNativeViewManager.h"
+#import "RNAppodealNativeView.h"
+
+@implementation RNAppodealNativeViewManager
+
+RCT_EXPORT_MODULE(RNAppodealNativeView);
+
+- (UIView *)view {
+    return [[RNAppodealNativeView alloc] initWithFrame:CGRectZero];
+}
+
+RCT_EXPORT_VIEW_PROPERTY(adId, NSString)
+RCT_EXPORT_VIEW_PROPERTY(placement, NSString)
+RCT_REMAP_VIEW_PROPERTY(template, templateName, NSString)
+
+RCT_EXPORT_VIEW_PROPERTY(onAdLoaded, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdFailedToLoad, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdClicked, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdExpired, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdShown, RCTBubblingEventBlock)
+
+@end

--- a/ios/RNAppodealNativeViewManager.mm
+++ b/ios/RNAppodealNativeViewManager.mm
@@ -11,7 +11,7 @@ RCT_EXPORT_MODULE(RNAppodealNativeView);
 
 RCT_EXPORT_VIEW_PROPERTY(adId, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placement, NSString)
-RCT_REMAP_VIEW_PROPERTY(template, templateName, NSString)
+RCT_REMAP_VIEW_PROPERTY(adTemplate, templateName, NSString)
 
 RCT_EXPORT_VIEW_PROPERTY(onAdLoaded, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdFailedToLoad, RCTBubblingEventBlock)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appodeal",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "React Native Module created to support Appodeal SDK for iOS and Android platforms",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "react-native-appodeal",
   "version": "4.3.0",
   "description": "React Native Module created to support Appodeal SDK for iOS and Android platforms",
-  "main": "./lib/module/index.js",
-  "types": "./lib/typescript/src/index.d.ts",
+  "main": "./src/index.tsx",
+  "react-native": "./src/index.tsx",
+  "types": "./src/index.tsx",
   "exports": {
     ".": {
+      "react-native": "./src/index.tsx",
+      "types": "./src/index.tsx",
       "source": "./src/index.tsx",
-      "types": "./lib/typescript/src/index.d.ts",
-      "default": "./lib/module/index.js"
+      "default": "./src/index.tsx"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appodeal",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "React Native Module created to support Appodeal SDK for iOS and Android platforms",
   "main": "./src/index.tsx",
   "react-native": "./src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appodeal",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "React Native Module created to support Appodeal SDK for iOS and Android platforms",
   "main": "./src/index.tsx",
   "react-native": "./src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appodeal",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "React Native Module created to support Appodeal SDK for iOS and Android platforms",
   "main": "./src/index.tsx",
   "react-native": "./src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appodeal",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "React Native Module created to support Appodeal SDK for iOS and Android platforms",
   "main": "./src/index.tsx",
   "react-native": "./src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appodeal",
-  "version": "4.3.5",
+  "version": "4.3.1",
   "description": "React Native Module created to support Appodeal SDK for iOS and Android platforms",
   "main": "./src/index.tsx",
   "react-native": "./src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appodeal",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "React Native Module created to support Appodeal SDK for iOS and Android platforms",
   "main": "./src/index.tsx",
   "react-native": "./src/index.tsx",

--- a/src/RNAppodeal.ts
+++ b/src/RNAppodeal.ts
@@ -334,9 +334,17 @@ const appodeal: Appodeal = {
   },
 
   getNativeAds: (count: number = 1): AppodealNativeAdInfo[] => {
+    // Android TurboModule Spec uses UnsafeObject → { ads: [...] }
     const result = NativeAppodeal.getNativeAds(count) as unknown;
     if (Array.isArray(result)) {
       return result as AppodealNativeAdInfo[];
+    }
+    if (
+      result &&
+      typeof result === 'object' &&
+      Array.isArray((result as { ads?: unknown }).ads)
+    ) {
+      return (result as { ads: AppodealNativeAdInfo[] }).ads;
     }
     return [];
   },

--- a/src/RNAppodeal.ts
+++ b/src/RNAppodeal.ts
@@ -3,7 +3,7 @@
  *
  * This module provides a complete interface to the Appodeal SDK for React Native applications.
  * It includes functionality for:
- * - Ad management (banner, interstitial, rewarded video, MREC)
+ * - Ad management (banner, interstitial, rewarded video, MREC, native)
  * - Analytics and revenue tracking
  * - In-app purchase validation
  * - Consent management (GDPR compliance)
@@ -19,6 +19,8 @@ import type {
   AppodealConsentStatus,
   AppodealPrivacyOptionsStatus,
   AppodealIOSPurchase,
+  AppodealNativeAdInfo,
+  AppodealNativeContentType,
   AppodealReward,
   Map,
 } from './types';
@@ -93,6 +95,31 @@ export interface Appodeal {
    * @param adTypes Ad types mask
    */
   cache(adTypes: AppodealAdType): void;
+  /**
+   * Pull cached native ads from the SDK (removes them from the SDK cache).
+   * Returns metadata + opaque ids for use with AppodealNative.
+   * @param count Number of ads to pull (Android max 5)
+   */
+  getNativeAds(count?: number): AppodealNativeAdInfo[];
+  /**
+   * Number of native ads currently available in the SDK cache / queue
+   */
+  getAvailableNativeAdsCount(): number;
+  /**
+   * Destroy a native ad previously returned by getNativeAds
+   * @param adId Opaque ad id
+   */
+  destroyNativeAd(adId: string): void;
+  /**
+   * Manually cache native ads
+   * @param count Number of ads to request (clamped 1–5 on Android)
+   */
+  cacheNativeAds(count?: number): void;
+  /**
+   * Preferred native media content type
+   * @param type auto | noVideo | video
+   */
+  setPreferredNativeContentType(type: AppodealNativeContentType): void;
   /**
    * Enables or disables autocache for specific ad type
    * @param adTypes Ad types mask
@@ -253,7 +280,7 @@ export interface Appodeal {
 /**
  * Plugin version constant
  */
-const PLUGIN_VERSION = '4.2.0';
+const PLUGIN_VERSION = '4.3.0';
 
 /**
  * Appodeal SDK implementation
@@ -304,6 +331,30 @@ const appodeal: Appodeal = {
 
   cache: (adTypes: AppodealAdType): void => {
     NativeAppodeal.cache(adTypes);
+  },
+
+  getNativeAds: (count: number = 1): AppodealNativeAdInfo[] => {
+    const result = NativeAppodeal.getNativeAds(count) as unknown;
+    if (Array.isArray(result)) {
+      return result as AppodealNativeAdInfo[];
+    }
+    return [];
+  },
+
+  getAvailableNativeAdsCount: (): number => {
+    return NativeAppodeal.getAvailableNativeAdsCount();
+  },
+
+  destroyNativeAd: (adId: string): void => {
+    NativeAppodeal.destroyNativeAd(adId);
+  },
+
+  cacheNativeAds: (count: number = 2): void => {
+    NativeAppodeal.cacheNativeAds(count);
+  },
+
+  setPreferredNativeContentType: (type: AppodealNativeContentType): void => {
+    NativeAppodeal.setPreferredNativeContentType(type);
   },
 
   setAutoCache: (adTypes: AppodealAdType, value: boolean): void => {

--- a/src/RNAppodeal.ts
+++ b/src/RNAppodeal.ts
@@ -280,7 +280,7 @@ export interface Appodeal {
 /**
  * Plugin version constant
  */
-const PLUGIN_VERSION = '4.3.0';
+const PLUGIN_VERSION = '4.3.1';
 
 /**
  * Appodeal SDK implementation

--- a/src/RNAppodealEvents.ts
+++ b/src/RNAppodealEvents.ts
@@ -52,6 +52,24 @@ export namespace AppodealInterstitialEvents {
 }
 
 /**
+ * Native ad events
+ */
+export namespace AppodealNativeEvents {
+  /** Fired when native ads are loaded into the queue */
+  export const LOADED = 'onNativeLoaded';
+  /** Fired when native ads fail to load */
+  export const FAILED_TO_LOAD = 'onNativeFailedToLoad';
+  /** Fired when a native ad is shown */
+  export const SHOWN = 'onNativeShown';
+  /** Fired when a native ad fails to show */
+  export const SHOW_FAILED = 'onNativeShowFailed';
+  /** Fired when a native ad is clicked */
+  export const CLICKED = 'onNativeClicked';
+  /** Fired when a native ad expires */
+  export const EXPIRED = 'onNativeExpired';
+}
+
+/**
  * Rewarded video ad events
  */
 export namespace AppodealRewardedEvents {

--- a/src/RNAppodealNative.tsx
+++ b/src/RNAppodealNative.tsx
@@ -1,8 +1,8 @@
 /**
- * Appodeal Native Ad Component
+ * Appodeal Native Ad Component — stock templates only.
  *
- * Renders a platform native-ad template (newsFeed / appWall / contentStream / gridCard)
- * bound to an ad id returned from Appodeal.getNativeAds().
+ * Templates: newsFeed / appWall / contentStream.
+ * For custom JSX layouts use AppodealNativeAdView + asset views.
  */
 import AppodealNativeView, {
   type NativeProps,

--- a/src/RNAppodealNative.tsx
+++ b/src/RNAppodealNative.tsx
@@ -1,0 +1,27 @@
+/**
+ * Appodeal Native Ad Component
+ *
+ * Renders a platform native-ad template (newsFeed / appWall / contentStream)
+ * bound to an ad id returned from Appodeal.getNativeAds().
+ */
+import AppodealNativeView, {
+  type NativeProps,
+} from './specs/AppodealNativeViewNativeComponent';
+
+const AppodealNative = ({
+  template = 'contentStream',
+  placement = 'default',
+  style,
+  ...rest
+}: NativeProps) => {
+  return (
+    <AppodealNativeView
+      template={template}
+      placement={placement}
+      style={style}
+      {...rest}
+    />
+  );
+};
+
+export default AppodealNative;

--- a/src/RNAppodealNative.tsx
+++ b/src/RNAppodealNative.tsx
@@ -1,7 +1,7 @@
 /**
  * Appodeal Native Ad Component
  *
- * Renders a platform native-ad template (newsFeed / appWall / contentStream)
+ * Renders a platform native-ad template (newsFeed / appWall / contentStream / gridCard)
  * bound to an ad id returned from Appodeal.getNativeAds().
  */
 import AppodealNativeView, {

--- a/src/RNAppodealNative.tsx
+++ b/src/RNAppodealNative.tsx
@@ -9,14 +9,14 @@ import AppodealNativeView, {
 } from './specs/AppodealNativeViewNativeComponent';
 
 const AppodealNative = ({
-  template = 'contentStream',
+  adTemplate = 'contentStream',
   placement = 'default',
   style,
   ...rest
 }: NativeProps) => {
   return (
     <AppodealNativeView
-      template={template}
+      adTemplate={adTemplate}
       placement={placement}
       style={style}
       {...rest}

--- a/src/RNAppodealNativeAdView.tsx
+++ b/src/RNAppodealNativeAdView.tsx
@@ -1,0 +1,66 @@
+/**
+ * Composable Appodeal native ad — AdMob-style layout in JSX.
+ *
+ * Stock templates: use <AppodealNative adTemplate="contentStream" />.
+ * Custom layout: compose assets under AppodealNativeAdView (both platforms).
+ */
+import React from 'react';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
+import AppodealNativeAdViewNative, {
+  type NativeProps as AdViewProps,
+} from './specs/AppodealNativeAdViewNativeComponent';
+import AppodealNativeAssetViewNative from './specs/AppodealNativeAssetViewNativeComponent';
+
+export type AppodealNativeAssetType =
+  | 'media'
+  | 'icon'
+  | 'title'
+  | 'description'
+  | 'callToAction'
+  | 'attribution';
+
+export type AppodealNativeAdViewProps = AdViewProps;
+
+export type AppodealNativeAssetProps = {
+  asset: AppodealNativeAssetType;
+  style?: StyleProp<ViewStyle | TextStyle>;
+  children?: React.ReactNode;
+};
+
+export const AppodealNativeAdView = (props: AppodealNativeAdViewProps) => {
+  return <AppodealNativeAdViewNative placement="default" {...props} />;
+};
+
+export const AppodealNativeAsset = ({
+  asset,
+  style,
+  ...rest
+}: AppodealNativeAssetProps) => {
+  return (
+    <AppodealNativeAssetViewNative asset={asset} style={style} {...rest} />
+  );
+};
+
+export const AppodealNativeMediaView = (
+  props: Omit<AppodealNativeAssetProps, 'asset'>
+) => <AppodealNativeAsset asset="media" {...props} />;
+
+export const AppodealNativeIconView = (
+  props: Omit<AppodealNativeAssetProps, 'asset'>
+) => <AppodealNativeAsset asset="icon" {...props} />;
+
+export const AppodealNativeTitleView = (
+  props: Omit<AppodealNativeAssetProps, 'asset'>
+) => <AppodealNativeAsset asset="title" {...props} />;
+
+export const AppodealNativeDescriptionView = (
+  props: Omit<AppodealNativeAssetProps, 'asset'>
+) => <AppodealNativeAsset asset="description" {...props} />;
+
+export const AppodealNativeCallToActionView = (
+  props: Omit<AppodealNativeAssetProps, 'asset'>
+) => <AppodealNativeAsset asset="callToAction" {...props} />;
+
+export const AppodealNativeAttributionView = (
+  props: Omit<AppodealNativeAssetProps, 'asset'>
+) => <AppodealNativeAsset asset="attribution" {...props} />;

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -21,7 +21,12 @@ describe('Appodeal Type Definitions', () => {
       expect(typeof AppodealAdType.INTERSTITIAL).toBe('number');
       expect(typeof AppodealAdType.BANNER).toBe('number');
       expect(typeof AppodealAdType.REWARDED_VIDEO).toBe('number');
+      expect(typeof AppodealAdType.NATIVE).toBe('number');
+      expect(AppodealAdType.NATIVE).toBe(1 << 7);
       expect(typeof AppodealAdType.MREC).toBe('number');
+      expect(AppodealAdType.ALL & AppodealAdType.NATIVE).toBe(
+        AppodealAdType.NATIVE
+      );
     });
 
     it('should have correct AppodealLogLevel values', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import Appodeal from './RNAppodeal';
 // React Native components
 export { default as AppodealBanner } from './RNAppodealBanner';
 export { default as AppodealMrec } from './RNAppodealMrec';
+export { default as AppodealNative } from './RNAppodealNative';
 
 // Export the main Appodeal interface
 export default Appodeal;
@@ -29,6 +30,9 @@ export type {
   AppodealIOSPurchase,
   AppodealAndroidPurchase,
   AppodealAdRevenue,
+  AppodealNativeAdInfo,
+  AppodealNativeContentType,
+  AppodealNativeTemplate,
   AppodealPurchaseValidationResult,
   Map,
 } from './types';
@@ -39,4 +43,5 @@ export {
   AppodealBannerEvents,
   AppodealInterstitialEvents,
   AppodealRewardedEvents,
+  AppodealNativeEvents,
 } from './RNAppodealEvents';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,21 @@ import Appodeal from './RNAppodeal';
 export { default as AppodealBanner } from './RNAppodealBanner';
 export { default as AppodealMrec } from './RNAppodealMrec';
 export { default as AppodealNative } from './RNAppodealNative';
+export {
+  AppodealNativeAdView,
+  AppodealNativeAsset,
+  AppodealNativeMediaView,
+  AppodealNativeIconView,
+  AppodealNativeTitleView,
+  AppodealNativeDescriptionView,
+  AppodealNativeCallToActionView,
+  AppodealNativeAttributionView,
+} from './RNAppodealNativeAdView';
+export type {
+  AppodealNativeAdViewProps,
+  AppodealNativeAssetProps,
+  AppodealNativeAssetType,
+} from './RNAppodealNativeAdView';
 
 // Export the main Appodeal interface
 export default Appodeal;

--- a/src/specs/AppodealNativeAdViewNativeComponent.ts
+++ b/src/specs/AppodealNativeAdViewNativeComponent.ts
@@ -14,8 +14,6 @@ export type NativeAdLoadFailedEvent = Readonly<{
 export interface NativeProps extends ViewProps {
   adId?: string;
   placement?: string;
-  /** Layout style: newsFeed | appWall | contentStream. Named adTemplate — `template` is a C++ keyword and breaks Fabric codegen. */
-  adTemplate?: string;
   onAdLoaded?: DirectEventHandler<NativeAdInfoEvent>;
   onAdFailedToLoad?: DirectEventHandler<NativeAdLoadFailedEvent>;
   onAdShown?: DirectEventHandler<NativeAdInfoEvent>;
@@ -24,5 +22,5 @@ export interface NativeProps extends ViewProps {
 }
 
 export default codegenNativeComponent<NativeProps>(
-  'RNAppodealNativeView'
+  'RNAppodealNativeAdView'
 ) as HostComponent<NativeProps>;

--- a/src/specs/AppodealNativeAssetViewNativeComponent.ts
+++ b/src/specs/AppodealNativeAssetViewNativeComponent.ts
@@ -1,0 +1,14 @@
+import type { HostComponent, ViewProps } from 'react-native';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+export interface NativeProps extends ViewProps {
+  /**
+   * Asset role inside AppodealNativeAdView:
+   * media | icon | title | description | callToAction | attribution
+   */
+  asset?: string;
+}
+
+export default codegenNativeComponent<NativeProps>(
+  'RNAppodealNativeAssetView'
+) as HostComponent<NativeProps>;

--- a/src/specs/AppodealNativeViewNativeComponent.ts
+++ b/src/specs/AppodealNativeViewNativeComponent.ts
@@ -1,0 +1,27 @@
+import type { HostComponent, ViewProps } from 'react-native';
+import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+export type NativeAdInfoEvent = Readonly<{
+  adId?: string;
+}>;
+
+export type NativeAdLoadFailedEvent = Readonly<{
+  adId?: string;
+  message?: string;
+}>;
+
+export interface NativeProps extends ViewProps {
+  adId?: string;
+  placement?: string;
+  template?: string;
+  onAdLoaded?: DirectEventHandler<NativeAdInfoEvent>;
+  onAdFailedToLoad?: DirectEventHandler<NativeAdLoadFailedEvent>;
+  onAdShown?: DirectEventHandler<NativeAdInfoEvent>;
+  onAdClicked?: DirectEventHandler<NativeAdInfoEvent>;
+  onAdExpired?: DirectEventHandler<NativeAdInfoEvent>;
+}
+
+export default codegenNativeComponent<NativeProps>(
+  'RNAppodealNativeView'
+) as HostComponent<NativeProps>;

--- a/src/specs/AppodealNativeViewNativeComponent.ts
+++ b/src/specs/AppodealNativeViewNativeComponent.ts
@@ -14,7 +14,8 @@ export type NativeAdLoadFailedEvent = Readonly<{
 export interface NativeProps extends ViewProps {
   adId?: string;
   placement?: string;
-  template?: string;
+  /** Layout style: newsFeed | appWall | contentStream. Named adTemplate — `template` is a C++ keyword and breaks Fabric codegen. */
+  adTemplate?: string;
   onAdLoaded?: DirectEventHandler<NativeAdInfoEvent>;
   onAdFailedToLoad?: DirectEventHandler<NativeAdLoadFailedEvent>;
   onAdShown?: DirectEventHandler<NativeAdInfoEvent>;

--- a/src/specs/AppodealNativeViewNativeComponent.ts
+++ b/src/specs/AppodealNativeViewNativeComponent.ts
@@ -14,7 +14,7 @@ export type NativeAdLoadFailedEvent = Readonly<{
 export interface NativeProps extends ViewProps {
   adId?: string;
   placement?: string;
-  /** Layout style: newsFeed | appWall | contentStream. Named adTemplate — `template` is a C++ keyword and breaks Fabric codegen. */
+  /** Layout style: newsFeed | appWall | contentStream | gridCard. Named adTemplate — `template` is a C++ keyword and breaks Fabric codegen. */
   adTemplate?: string;
   onAdLoaded?: DirectEventHandler<NativeAdInfoEvent>;
   onAdFailedToLoad?: DirectEventHandler<NativeAdLoadFailedEvent>;

--- a/src/specs/NativeAppodealModule.ts
+++ b/src/specs/NativeAppodealModule.ts
@@ -74,6 +74,13 @@ export interface Spec extends TurboModule {
   ): Promise<AppodealPurchaseValidationResult>;
   trackEvent(name: string, parameters: UnsafeObject): void;
 
+  // Native ads
+  getNativeAds(count: number): UnsafeObject;
+  getAvailableNativeAdsCount(): number;
+  destroyNativeAd(adId: string): void;
+  cacheNativeAds(count: number): void;
+  setPreferredNativeContentType(type: string): void;
+
   // Bidon
   setBidonEndpoint(endpoint: string): void;
   getBidonEndpoint(): string | null;

--- a/src/types/AppodealAdTypes.ts
+++ b/src/types/AppodealAdTypes.ts
@@ -16,13 +16,38 @@ export enum AppodealAdType {
   BANNER_BOTTOM = 1 << 3, // 8
   BANNER_TOP = 1 << 4, // 16
   REWARDED_VIDEO = 1 << 5, // 32
+  NATIVE = 1 << 7, // 128
   MREC = 1 << 8, // 256
   ALL = INTERSTITIAL |
     BANNER |
     BANNER_BOTTOM |
     BANNER_TOP |
     REWARDED_VIDEO |
+    NATIVE |
     MREC,
+}
+
+/**
+ * Preferred media content type for native ads
+ */
+export type AppodealNativeContentType = 'auto' | 'noVideo' | 'video';
+
+/**
+ * Native ad template used by AppodealNative view
+ */
+export type AppodealNativeTemplate = 'newsFeed' | 'appWall' | 'contentStream';
+
+/**
+ * Metadata for a cached native ad pulled from the SDK
+ */
+export interface AppodealNativeAdInfo {
+  id: string;
+  title: string;
+  description: string;
+  callToAction: string;
+  rating: number;
+  containsVideo: boolean;
+  predictedEcpm: number;
 }
 
 /**

--- a/src/types/AppodealAdTypes.ts
+++ b/src/types/AppodealAdTypes.ts
@@ -35,7 +35,12 @@ export type AppodealNativeContentType = 'auto' | 'noVideo' | 'video';
 /**
  * Native ad template used by AppodealNative view
  */
-export type AppodealNativeTemplate = 'newsFeed' | 'appWall' | 'contentStream';
+export type AppodealNativeTemplate =
+  | 'newsFeed'
+  | 'appWall'
+  | 'contentStream'
+  /** Portrait feed card: media top ~56%, icon/title/CTA below (matches AdMob grid). */
+  | 'gridCard';
 
 /**
  * Metadata for a cached native ad pulled from the SDK

--- a/src/types/AppodealAdTypes.ts
+++ b/src/types/AppodealAdTypes.ts
@@ -33,14 +33,10 @@ export enum AppodealAdType {
 export type AppodealNativeContentType = 'auto' | 'noVideo' | 'video';
 
 /**
- * Native ad template used by AppodealNative view
+ * Native ad template used by AppodealNative view (stock SDK templates).
+ * Custom layouts use AppodealNativeAdView + asset children instead.
  */
-export type AppodealNativeTemplate =
-  | 'newsFeed'
-  | 'appWall'
-  | 'contentStream'
-  /** Portrait feed card: media top ~56%, icon/title/CTA below (matches AdMob grid). */
-  | 'gridCard';
+export type AppodealNativeTemplate = 'newsFeed' | 'appWall' | 'contentStream';
 
 /**
  * Metadata for a cached native ad pulled from the SDK

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,12 @@
 // Ad-related types
 export { AppodealAdType } from './AppodealAdTypes';
 
-export type { AppodealAdRevenue } from './AppodealAdTypes';
+export type {
+  AppodealAdRevenue,
+  AppodealNativeAdInfo,
+  AppodealNativeContentType,
+  AppodealNativeTemplate,
+} from './AppodealAdTypes';
 
 // Consent-related types
 export {


### PR DESCRIPTION
## Summary
Adds **Native ads** support to the React Native SDK (Android + iOS + JS) — the only Appodeal ad format that was missing from the RN bridge.

Two ways to render native ads:
1. **Stock templates** — drop-in views (`newsFeed` / `appWall` / `contentStream`), same as the native Android/iOS SDKs
2. **Composable assets** — AdMob-style JSX layout (`AppodealNativeAdView` + media/icon/title/description/CTA/attribution children) so apps can style native ads in React Native without custom native modules

## API

### Module
- `AppodealAdType.NATIVE`
- `cacheNativeAds(count)`, `getNativeAds(count)`, `getAvailableNativeAdsCount()`, `destroyNativeAd(id)`
- `setPreferredNativeContentType(type)`
- `AppodealNativeEvents` (`onNativeLoaded`, `onNativeFailedToLoad`, `onNativeShown`, `onNativeClicked`, `onNativeExpired`)

### Stock template view
```jsx
<AppodealNative adId={id} placement="default" adTemplate="contentStream" />
```

### Composable (custom layout)
```jsx
<AppodealNativeAdView adId={id} placement="default">
  <AppodealNativeMediaView style={...} />
  <AppodealNativeIconView style={...} />
  <AppodealNativeTitleView style={...} />
  <AppodealNativeDescriptionView style={...} />
  <AppodealNativeCallToActionView style={...} />
  <AppodealNativeAttributionView style={...} />
</AppodealNativeAdView>
```

## Platform notes
- **Android:** `Appodeal.NATIVE`, `NativeCallbacks`, ad store, stock `NativeAdView*` templates + composable `NativeAdView` with asset binding
- **iOS:** `APDNativeAdQueue` store + `getViewForPlacement` / custom asset views

## Test plan
- [ ] Initialize with `AppodealAdType.NATIVE` on Android/iOS
- [ ] `cacheNativeAds` → `onNativeLoaded` → `getNativeAds(1)` returns metadata
- [ ] `<AppodealNative adId=... adTemplate="contentStream" />` shows a stock template
- [ ] `<AppodealNativeAdView>` + asset children render a custom layout
- [ ] Existing interstitial / rewarded / banner / MREC still work